### PR TITLE
Update update_home_assistant_configuration.md

### DIFF
--- a/docs/update_home_assistant_configuration.md
+++ b/docs/update_home_assistant_configuration.md
@@ -66,7 +66,7 @@ eltako:
         name: "Socket Basement"   # optional: display name
         sender:                   # virtual switch in Home Assistant.
           id: 00-00-B0-02         # every sender needs it's own address which needs to be entered in PCT14 / actuator with function group 51 for FSR14.
-          eep: A5-38-08 
+          eep: F6-02-01 
 
       # sensor can be almost everything what can send data.
       sensor:


### PR DESCRIPTION
Switch Sender eep A5-38-08 is not allow, change to F6-02-01.

Invalid config for 'eltako' at configuration.yaml, line 506: value must be one of ['F6-02-01', 'F6-02-02'] for dictionary value 'eltako->gateway->0->devices->switch->0->sender->eep', got 'A5-38-08'