### PR TITLE
Version 1.3.7 Restore Device States after HA Restart

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,7 +2,8 @@
 
 ## Version 1.3.7 Import Cleanup
 * Trial to remove import warnings (Reported Issue: https://github.com/grimmpp/home-assistant-eltako/issues/61)
-* &#x1F41E; Removed entity_id bug from GatewayConnectionState &#x1F41E; 
+* &#x1F41E; Removed entity_id bug from GatewayConnectionState &#x1F41E; => Requires removing and adding gateway again ❗
+* Added state cache. When restarting HA entities will show previouse state after start up.
 
 ## Version 1.3.6 Dependencies fixed for 1.3.5
 * &#x1F41E; Wrong dependency in manifest &#x1F41E; 

--- a/changes.md
+++ b/changes.md
@@ -1,6 +1,6 @@
 # Changes and Feature List
 
-## Version 1.3.7 Import Cleanup
+## Version 1.3.7 Restore Device States after HA Restart
 * Trial to remove import warnings (Reported Issue: https://github.com/grimmpp/home-assistant-eltako/issues/61)
 * &#x1F41E; Removed entity_id bug from GatewayConnectionState &#x1F41E; => Requires removing and adding gateway again ❗
 * Added state cache of device entities. When restarting HA entities like temperature sensors will show previouse state/value after restart.

--- a/changes.md
+++ b/changes.md
@@ -3,7 +3,7 @@
 ## Version 1.3.7 Import Cleanup
 * Trial to remove import warnings (Reported Issue: https://github.com/grimmpp/home-assistant-eltako/issues/61)
 * &#x1F41E; Removed entity_id bug from GatewayConnectionState &#x1F41E; => Requires removing and adding gateway again ❗
-* Added state cache. When restarting HA entities will show previouse state after start up.
+* Added state cache of device entities. When restarting HA entities like temperature sensors will show previouse state/value after restart.
 
 ## Version 1.3.6 Dependencies fixed for 1.3.5
 * &#x1F41E; Wrong dependency in manifest &#x1F41E; 

--- a/changes.md
+++ b/changes.md
@@ -1,9 +1,11 @@
 # Changes and Feature List
 
 ## Version 1.3.7 Restore Device States after HA Restart
-* Trial to remove import warnings (Reported Issue: https://github.com/grimmpp/home-assistant-eltako/issues/61)
+* Trial to remove import warnings 
+  Reported Issue: https://github.com/grimmpp/home-assistant-eltako/issues/61
 * &#x1F41E; Removed entity_id bug from GatewayConnectionState &#x1F41E; => Requires removing and adding gateway again ❗
-* Added state cache of device entities. When restarting HA entities like temperature sensors will show previouse state/value after restart.
+* Added state cache of device entities. When restarting HA entities like temperature sensors will show previouse state/value after restart. 
+  Reported Feature: https://github.com/grimmpp/home-assistant-eltako/issues/63
 
 ## Version 1.3.6 Dependencies fixed for 1.3.5
 * &#x1F41E; Wrong dependency in manifest &#x1F41E; 

--- a/custom_components/eltako/binary_sensor.py
+++ b/custom_components/eltako/binary_sensor.py
@@ -244,12 +244,12 @@ class GatewayConnectionState(AbstractBinarySensor):
     """Protocols last time when message received"""
 
     def __init__(self, platform: str, gateway: EnOceanGateway):
-        description_key = "Gateway_Connection_State"
+        self.description_key = "Gateway_Connection_State"
 
         self._attr_icon = "mdi:connection"
         self._attr_name = "Connected"
         
-        super().__init__(platform, gateway, gateway.base_id, dev_name="Connected", description_key=description_key)
+        super().__init__(platform, gateway, gateway.base_id, dev_name="Connected")
         self.gateway.set_connection_state_changed_handler(self.async_value_changed)
 
     @property

--- a/custom_components/eltako/binary_sensor.py
+++ b/custom_components/eltako/binary_sensor.py
@@ -55,7 +55,7 @@ async def async_setup_entry(
     async_add_entities(entities)
     
 
-class EltakoBinarySensor(BinarySensorEntity, EltakoEntity, RestoreEntity):
+class EltakoBinarySensor(EltakoEntity, RestoreEntity, BinarySensorEntity):
     """Representation of Eltako binary sensors such as wall switches.
 
     Supported EEPs (EnOcean Equipment Profiles):

--- a/custom_components/eltako/binary_sensor.py
+++ b/custom_components/eltako/binary_sensor.py
@@ -53,6 +53,10 @@ async def async_setup_entry(
     # dev_id validation not possible because there can be bus sensors as well as decentralized sensors.
     log_entities_to_be_added(entities, platform)
     async_add_entities(entities)
+
+async def async_remove_entry(hass: HomeAssistant, entry) -> None:
+    LOGGER.debug(f"REMOVE: {entry}")
+    """Handle removal of an entry."""
     
 class AbstractBinarySensor(EltakoEntity, RestoreEntity, BinarySensorEntity):
     

--- a/custom_components/eltako/binary_sensor.py
+++ b/custom_components/eltako/binary_sensor.py
@@ -54,9 +54,6 @@ async def async_setup_entry(
     log_entities_to_be_added(entities, platform)
     async_add_entities(entities)
 
-async def async_remove_entry(hass: HomeAssistant, entry) -> None:
-    LOGGER.debug(f"REMOVE: {entry}")
-    """Handle removal of an entry."""
     
 class AbstractBinarySensor(EltakoEntity, RestoreEntity, BinarySensorEntity):
     

--- a/custom_components/eltako/binary_sensor.py
+++ b/custom_components/eltako/binary_sensor.py
@@ -55,7 +55,7 @@ async def async_setup_entry(
     async_add_entities(entities)
     
 
-class EltakoBinarySensor(EltakoEntity, BinarySensorEntity, RestoreEntity):
+class EltakoBinarySensor(BinarySensorEntity, EltakoEntity, RestoreEntity):
     """Representation of Eltako binary sensors such as wall switches.
 
     Supported EEPs (EnOcean Equipment Profiles):

--- a/custom_components/eltako/binary_sensor.py
+++ b/custom_components/eltako/binary_sensor.py
@@ -244,12 +244,12 @@ class GatewayConnectionState(AbstractBinarySensor):
     """Protocols last time when message received"""
 
     def __init__(self, platform: str, gateway: EnOceanGateway):
-        self.description_key = "Gateway_Connection_State"
+        description_key = "Gateway_Connection_State"
 
         self._attr_icon = "mdi:connection"
         self._attr_name = "Connected"
         
-        super().__init__(platform, gateway, gateway.base_id, "Connected")
+        super().__init__(platform, gateway, gateway.base_id, dev_name="Connected", description_key=description_key)
         self.gateway.set_connection_state_changed_handler(self.async_value_changed)
 
     @property

--- a/custom_components/eltako/binary_sensor.py
+++ b/custom_components/eltako/binary_sensor.py
@@ -71,7 +71,6 @@ class EltakoBinarySensor(EltakoEntity, BinarySensorEntity, RestoreEntity):
         self.invert_signal = invert_signal
         self._attr_device_class = device_class
     
-    @final
     @property
     def state(self) -> Literal["on", "off"] | None:
         """Return the state of the binary sensor."""

--- a/custom_components/eltako/binary_sensor.py
+++ b/custom_components/eltako/binary_sensor.py
@@ -74,6 +74,7 @@ class EltakoBinarySensor(EltakoEntity, BinarySensorEntity, RestoreEntity):
     @property
     def state(self) -> Literal["on", "off"] | None:
         """Return the state of the binary sensor."""
+        print("entered state in eltako_binary_sensor")
         if (is_on := self.is_on) is None:
             return None
         return STATE_ON if is_on else STATE_OFF

--- a/custom_components/eltako/binary_sensor.py
+++ b/custom_components/eltako/binary_sensor.py
@@ -72,12 +72,9 @@ class EltakoBinarySensor(EltakoEntity, BinarySensorEntity, RestoreEntity):
         self._attr_device_class = device_class
     
     @property
-    def state(self) -> Literal["on", "off"] | None:
-        """Return the state of the binary sensor."""
+    def state(self) -> str:
         print("entered state in eltako_binary_sensor")
-        if (is_on := self.is_on) is None:
-            return None
-        return STATE_ON if is_on else STATE_OFF
+        return STATE_ON if self._attr_is_on else STATE_OFF
 
     def value_changed(self, msg: ESP2Message):
         """Fire an event with the data that have changed.

--- a/custom_components/eltako/binary_sensor.py
+++ b/custom_components/eltako/binary_sensor.py
@@ -1,12 +1,13 @@
 """Support for Eltako binary sensors."""
 from __future__ import annotations
+from typing import Literal, final
 
 from eltakobus.util import AddressExpression, b2a, b2s
 from eltakobus.eep import *
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant import config_entries
-from homeassistant.const import CONF_DEVICE_CLASS
+from homeassistant.const import CONF_DEVICE_CLASS, STATE_ON, STATE_OFF
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity import DeviceInfo
@@ -69,6 +70,14 @@ class EltakoBinarySensor(EltakoEntity, BinarySensorEntity, RestoreEntity):
         super().__init__(platform, gateway, dev_id, dev_name, dev_eep)
         self.invert_signal = invert_signal
         self._attr_device_class = device_class
+    
+    @final
+    @property
+    def state(self) -> Literal["on", "off"] | None:
+        """Return the state of the binary sensor."""
+        if (is_on := self.is_on) is None:
+            return None
+        return STATE_ON if is_on else STATE_OFF
 
     def value_changed(self, msg: ESP2Message):
         """Fire an event with the data that have changed.

--- a/custom_components/eltako/binary_sensor.py
+++ b/custom_components/eltako/binary_sensor.py
@@ -70,11 +70,7 @@ class EltakoBinarySensor(EltakoEntity, RestoreEntity, BinarySensorEntity):
         super().__init__(platform, gateway, dev_id, dev_name, dev_eep)
         self.invert_signal = invert_signal
         self._attr_device_class = device_class
-    
-    @property
-    def state(self) -> str:
-        print("entered state in eltako_binary_sensor")
-        return STATE_ON if self._attr_is_on else STATE_OFF
+        
 
     def value_changed(self, msg: ESP2Message):
         """Fire an event with the data that have changed.

--- a/custom_components/eltako/binary_sensor.py
+++ b/custom_components/eltako/binary_sensor.py
@@ -244,12 +244,12 @@ class GatewayConnectionState(AbstractBinarySensor):
     """Protocols last time when message received"""
 
     def __init__(self, platform: str, gateway: EnOceanGateway):
-        self.description_key = "Gateway_Connection_State"
+        key = "Gateway_Connection_State"
 
         self._attr_icon = "mdi:connection"
         self._attr_name = "Connected"
         
-        super().__init__(platform, gateway, gateway.base_id, dev_name="Connected")
+        super().__init__(platform, gateway, gateway.base_id, dev_name="Connected", description_key=key)
         self.gateway.set_connection_state_changed_handler(self.async_value_changed)
 
     @property

--- a/custom_components/eltako/climate.py
+++ b/custom_components/eltako/climate.py
@@ -145,12 +145,12 @@ class ClimateController(EltakoEntity, ClimateEntity, RestoreEntity):
         self._update_task = asyncio.ensure_future(self._wrapped_update(), loop=self._loop)
 
 
-    def load_value_initially(self, latest_state:State):
-        # cast state:str to actual value
-        LOGGER.warn(f"[climate {self.dev_id}] Load value initially not yet implemented!!!")
-        LOGGER.debug(f"[climate {self.dev_id}] eneity unique_id: {self.unique_id}")
-        LOGGER.debug(f"[climate {self.dev_id}] latest state - state: {latest_state.state}")
-        LOGGER.debug(f"[climate {self.dev_id}] latest state - attributes: {latest_state.attributes}")
+    # def load_value_initially(self, latest_state:State):
+    #     # cast state:str to actual value
+    #     LOGGER.warn(f"[climate {self.dev_id}] Load value initially not yet implemented!!!")
+    #     LOGGER.debug(f"[climate {self.dev_id}] eneity unique_id: {self.unique_id}")
+    #     LOGGER.debug(f"[climate {self.dev_id}] latest state - state: {latest_state.state}")
+    #     LOGGER.debug(f"[climate {self.dev_id}] latest state - attributes: {latest_state.attributes}")
 
 
     async def _wrapped_update(self, *args) -> None:

--- a/custom_components/eltako/climate.py
+++ b/custom_components/eltako/climate.py
@@ -152,11 +152,11 @@ class ClimateController(EltakoEntity, ClimateEntity, RestoreEntity):
         LOGGER.debug(f"[climate {self.dev_id}] latest state - attributes: {latest_state.attributes}")
 
         try:
-            self.hvac_modes = []
-            for m_str in latest_state.attributes.get('hvac_modes', []):
-                for m_enum in HVACMode:
-                    if m_str == m_enum.value:
-                        self.hvac_modes.append(m_enum)
+            # self.hvac_modes = []
+            # for m_str in latest_state.attributes.get('hvac_modes', []):
+            #     for m_enum in HVACMode:
+            #         if m_str == m_enum.value:
+            #             self.hvac_modes.append(m_enum)
 
             self._attr_current_temperature = float(latest_state.attributes.get('current_temperature', None) )
             self._attr_target_temperature = float(latest_state.attributes.get('temperature', None) )

--- a/custom_components/eltako/climate.py
+++ b/custom_components/eltako/climate.py
@@ -82,7 +82,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-def validate_ids_of_climate(entities:[EltakoEntity]):
+def validate_ids_of_climate(entities:list[EltakoEntity]):
     for e in entities:
         e.validate_dev_id()
         e.validate_sender_id()
@@ -143,6 +143,14 @@ class ClimateController(EltakoEntity, ClimateEntity, RestoreEntity):
 
         self._loop = asyncio.get_event_loop()
         self._update_task = asyncio.ensure_future(self._wrapped_update(), loop=self._loop)
+
+
+    def load_value_initially(self, latest_state:State):
+        # cast state:str to actual value
+        LOGGER.warn(f"[climate {self.dev_id}] Load value initially not yet implemented!!!")
+        LOGGER.debug(f"[climate {self.dev_id}] eneity unique_id: {self.unique_id}")
+        LOGGER.debug(f"[climate {self.dev_id}] latest state - state: {latest_state.state}")
+        LOGGER.debug(f"[climate {self.dev_id}] latest state - attributes: {latest_state.attributes}")
 
 
     async def _wrapped_update(self, *args) -> None:

--- a/custom_components/eltako/climate.py
+++ b/custom_components/eltako/climate.py
@@ -157,16 +157,14 @@ class ClimateController(EltakoEntity, ClimateEntity, RestoreEntity):
                     if m_str == m_enum.value:
                         self.hvac_modes.append(m_enum)
 
-            self._attr_current_temperature = float(latest_state.attributes.get('current_temperature', None) )
-            self._attr_target_temperature = float(latest_state.attributes.get('temperature', None) )
+            self._attr_current_temperature = latest_state.attributes.get('current_temperature', None)
+            self._attr_target_temperature = latest_state.attributes.get('temperature', None)
 
-            if 'unknown' == latest_state.state:
-                self._attr_hvac_mode = None
-            else:
-                for m_enum in HVACMode:
-                    if latest_state.state == m_enum.value:
-                        self._attr_hvac_mode = m_enum
-                        break
+            self._attr_hvac_mode = None
+            for m_enum in HVACMode:
+                if latest_state.state == m_enum.value:
+                    self._attr_hvac_mode = m_enum
+                    break
                 
         except Exception as e:
             self._attr_hvac_mode = None

--- a/custom_components/eltako/climate.py
+++ b/custom_components/eltako/climate.py
@@ -145,12 +145,37 @@ class ClimateController(EltakoEntity, ClimateEntity, RestoreEntity):
         self._update_task = asyncio.ensure_future(self._wrapped_update(), loop=self._loop)
 
 
-    # def load_value_initially(self, latest_state:State):
-    #     # cast state:str to actual value
-    #     LOGGER.warn(f"[climate {self.dev_id}] Load value initially not yet implemented!!!")
-    #     LOGGER.debug(f"[climate {self.dev_id}] eneity unique_id: {self.unique_id}")
-    #     LOGGER.debug(f"[climate {self.dev_id}] latest state - state: {latest_state.state}")
-    #     LOGGER.debug(f"[climate {self.dev_id}] latest state - attributes: {latest_state.attributes}")
+    def load_value_initially(self, latest_state:State):
+        LOGGER.warn(f"[climate {self.dev_id}] Load value initially not yet implemented!!!")
+        LOGGER.debug(f"[climate {self.dev_id}] eneity unique_id: {self.unique_id}")
+        LOGGER.debug(f"[climate {self.dev_id}] latest state - state: {latest_state.state}")
+        LOGGER.debug(f"[climate {self.dev_id}] latest state - attributes: {latest_state.attributes}")
+
+        try:
+            self.hvac_modes = []
+            for m_str in latest_state.attributes.get('hvac_modes', []):
+                for m_enum in HVACMode:
+                    if m_str == m_enum.value:
+                        self.hvac_modes.append(m_enum)
+
+            self._attr_current_temperature = float(latest_state.attributes.get('current_temperature', None) )
+            self._attr_target_temperature = float(latest_state.attributes.get('temperature', None) )
+
+            if 'unknown' == latest_state.state:
+                self._attr_hvac_mode = None
+            else:
+                for m_enum in HVACMode:
+                    if latest_state.state == m_enum.value:
+                        self._attr_hvac_mode = m_enum
+                        break
+                
+        except Exception as e:
+            self._attr_hvac_mode = None
+            raise e
+        
+        self.schedule_update_ha_state()
+
+        LOGGER.debug(f"[climate {self.dev_id}] value initially loaded: [state: {self.state}, modes: [{self.hvac_modes}], current temp: {self.current_temperature}, target temp: {self.target_temperature}]")
 
 
     async def _wrapped_update(self, *args) -> None:

--- a/custom_components/eltako/climate.py
+++ b/custom_components/eltako/climate.py
@@ -146,17 +146,16 @@ class ClimateController(EltakoEntity, ClimateEntity, RestoreEntity):
 
 
     def load_value_initially(self, latest_state:State):
-        LOGGER.warn(f"[climate {self.dev_id}] Load value initially not yet implemented!!!")
-        LOGGER.debug(f"[climate {self.dev_id}] eneity unique_id: {self.unique_id}")
-        LOGGER.debug(f"[climate {self.dev_id}] latest state - state: {latest_state.state}")
-        LOGGER.debug(f"[climate {self.dev_id}] latest state - attributes: {latest_state.attributes}")
+        # LOGGER.debug(f"[climate {self.dev_id}] eneity unique_id: {self.unique_id}")
+        # LOGGER.debug(f"[climate {self.dev_id}] latest state - state: {latest_state.state}")
+        # LOGGER.debug(f"[climate {self.dev_id}] latest state - attributes: {latest_state.attributes}")
 
         try:
-            # self.hvac_modes = []
-            # for m_str in latest_state.attributes.get('hvac_modes', []):
-            #     for m_enum in HVACMode:
-            #         if m_str == m_enum.value:
-            #             self.hvac_modes.append(m_enum)
+            self.hvac_modes = []
+            for m_str in latest_state.attributes.get('hvac_modes', []):
+                for m_enum in HVACMode:
+                    if m_str == m_enum.value:
+                        self.hvac_modes.append(m_enum)
 
             self._attr_current_temperature = float(latest_state.attributes.get('current_temperature', None) )
             self._attr_target_temperature = float(latest_state.attributes.get('temperature', None) )
@@ -171,6 +170,8 @@ class ClimateController(EltakoEntity, ClimateEntity, RestoreEntity):
                 
         except Exception as e:
             self._attr_hvac_mode = None
+            self._attr_current_temperature = None
+            self._attr_target_temperature = None
             raise e
         
         self.schedule_update_ha_state()

--- a/custom_components/eltako/config_helpers.py
+++ b/custom_components/eltako/config_helpers.py
@@ -165,7 +165,7 @@ def get_gateway_name(dev_name:str, dev_type:str, dev_id: int, base_id:AddressExp
     return f"{dev_name} - {dev_type} (Id: {dev_id}, BaseId: {format_address(base_id)})"
 
 def format_address(address: AddressExpression, separator:str='-') -> str:
-    return b2a(address[0], '-').upper()
+    return b2a(address[0], separator).upper()
 
 def get_device_name(dev_name: str, dev_id: AddressExpression, general_config: dict) -> str:
     if general_config[CONF_SHOW_DEV_ID_IN_DEV_NAME]:

--- a/custom_components/eltako/cover.py
+++ b/custom_components/eltako/cover.py
@@ -276,6 +276,10 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
                     self._attr_is_closed = False
                     self._attr_is_opening = False
                     self._attr_is_closing = False
+                else:
+                    self._attr_is_closed = False
+                    self._attr_is_opening = True
+                    self._attr_is_closing = True
 
             
             LOGGER.debug(f"[cover {self.dev_id}] state: {self.state}, opening: {self.is_opening}, closing: {self.is_closing}, closed: {self.is_closed}, position: {self.current_cover_position}")

--- a/custom_components/eltako/cover.py
+++ b/custom_components/eltako/cover.py
@@ -222,6 +222,7 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
             return
         
         if self.dev_eep in [G5_3F_7F]:
+            LOGGER.debug(f"[cover {self.dev_id}] G5_3F_7F - {decoded}")
             if decoded.time is not None and decoded.direction is not None and self._time_closes is not None and self._time_opens is not None:
                 time_in_seconds = decoded.time / 10.0
                 

--- a/custom_components/eltako/cover.py
+++ b/custom_components/eltako/cover.py
@@ -78,8 +78,8 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
 
 
     def load_value_initially(self, latest_state:State):
-        LOGGER.debug(f"[cover {self.dev_id}] latest state: {latest_state.state}")
-        LOGGER.debug(f"[cover {self.dev_id}] latest state attributes: {latest_state.attributes}")
+        # LOGGER.debug(f"[cover {self.dev_id}] latest state: {latest_state.state}")
+        # LOGGER.debug(f"[cover {self.dev_id}] latest state attributes: {latest_state.attributes}")
         try:
             if 'unknown' == latest_state.state:
                 self._attr_current_cover_position = None

--- a/custom_components/eltako/cover.py
+++ b/custom_components/eltako/cover.py
@@ -260,13 +260,13 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
                     self._attr_current_cover_position = min(self._attr_current_cover_position + int(time_in_seconds / self._time_opens * 100.0), 100)
                     self._attr_is_opening = True
                     self._attr_is_closing = False
-                    self._attr_is_closed = False
+                    self._attr_is_closed = None
                     
                 else: # down
                     self._attr_current_cover_position = max(self._attr_current_cover_position - int(time_in_seconds / self._time_closes * 100.0), 0)
                     self._attr_is_opening = False
                     self._attr_is_closing = True
-                    self._attr_is_closed = False
+                    self._attr_is_closed = None
                     
                 if self._attr_current_cover_position == 0:
                     self._attr_is_closed = True
@@ -276,6 +276,7 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
                     self._attr_is_closed = False
                     self._attr_is_opening = False
                     self._attr_is_closing = False
+
             
             LOGGER.debug(f"[cover {self.dev_id}] state: {self.state}, opening: {self.is_opening}, closing: {self.is_closing}, closed: {self.is_closed}, position: {self.current_cover_position}")
 

--- a/custom_components/eltako/cover.py
+++ b/custom_components/eltako/cover.py
@@ -276,6 +276,7 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
                     self._attr_is_closed = False
                     self._attr_is_opening = False
                     self._attr_is_closing = False
-                
+            
+            LOGGER.debug(f"[cover {self.dev_id}] state: {self.state}, opening: {self.is_opening}, closing: {self.is_closing}, closed: {self.is_closed}, position: {self.current_cover_position}")
 
             self.schedule_update_ha_state()

--- a/custom_components/eltako/cover.py
+++ b/custom_components/eltako/cover.py
@@ -233,25 +233,6 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
         
         if self.dev_eep in [G5_3F_7F]:
             LOGGER.debug(f"[cover {self.dev_id}] G5_3F_7F - {decoded.__dict__}")
-            if decoded.time is not None and decoded.direction is not None and self._time_closes is not None and self._time_opens is not None:
-
-                time_in_seconds = decoded.time / 10.0
-                
-                if decoded.direction == 0x01: # up
-                    self._attr_current_cover_position = min(self._attr_current_cover_position + int(time_in_seconds / self._time_opens * 100.0), 100)
-                    
-                else: # down
-                    self._attr_current_cover_position = max(self._attr_current_cover_position - int(time_in_seconds / self._time_closes * 100.0), 0)
-                    
-                if self._attr_current_cover_position == 0:
-                    self._attr_is_closed = True
-                elif self._attr_current_cover_position == 100:
-                    self._attr_is_closed = False
-                else:
-                    self._attr_is_closed = None
-
-                self._attr_is_closing = False
-                self._attr_is_opening = False
 
             if decoded.state == 0x02: # down
                 self._attr_is_closing = True
@@ -269,7 +250,32 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
             elif decoded.state == 0x70: # open
                 self._attr_is_opening = False
                 self._attr_is_closing = False
-                self._attr_is_closed = False
+                self._attr_is_closed = None
                 self._attr_current_cover_position = 100
+            elif decoded.time is not None and decoded.direction is not None and self._time_closes is not None and self._time_opens is not None:
+
+                time_in_seconds = decoded.time / 10.0
+                
+                if decoded.direction == 0x01: # up
+                    self._attr_current_cover_position = min(self._attr_current_cover_position + int(time_in_seconds / self._time_opens * 100.0), 100)
+                    self._attr_is_opening = True
+                    self._attr_is_closing = False
+                    self._attr_is_closed = False
+                    
+                else: # down
+                    self._attr_current_cover_position = max(self._attr_current_cover_position - int(time_in_seconds / self._time_closes * 100.0), 0)
+                    self._attr_is_opening = False
+                    self._attr_is_closing = True
+                    self._attr_is_closed = False
+                    
+                if self._attr_current_cover_position == 0:
+                    self._attr_is_closed = True
+                    self._attr_is_opening = False
+                    self._attr_is_closing = False
+                elif self._attr_current_cover_position == 100:
+                    self._attr_is_closed = False
+                    self._attr_is_opening = False
+                    self._attr_is_closing = False
+                
 
             self.schedule_update_ha_state()

--- a/custom_components/eltako/cover.py
+++ b/custom_components/eltako/cover.py
@@ -78,6 +78,8 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
 
 
     def load_value_initially(self, latest_state:State):
+        LOGGER.debug(f"[cover {self.dev_id}] latest state: {latest_state.state}")
+        LOGGER.debug(f"[cover {self.dev_id}] latest state attributes: {latest_state.attributes}")
         try:
             if 'unknown' == latest_state.state:
                 self._attr_current_cover_position = None
@@ -97,16 +99,16 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
                 elif latest_state.state == STATE_CLOSING:
                     self._attr_is_opening = False
                     self._attr_is_closing = True
-                    self._attr_is_closed = None
+                    self._attr_is_closed = False
                 elif latest_state.state == STATE_OPENING:
                     self._attr_is_opening = True
                     self._attr_is_closing = False
-                    self._attr_is_closed = None
+                    self._attr_is_closed = False
             
         except Exception as e:
             self._attr_current_cover_position = None
-            self._attr_is_opening = False
-            self._attr_is_closing = False
+            self._attr_is_opening = None
+            self._attr_is_closing = None
             self._attr_is_closed = None # means undefined state
             raise e
         
@@ -133,7 +135,7 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
         if self.general_settings[CONF_FAST_STATUS_CHANGE]:
             self._attr_is_opening = True
             self._attr_is_closing = False
-            self._attr_is_closed = None
+            self._attr_is_closed = False
 
             self.schedule_update_ha_state()
 
@@ -157,7 +159,7 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
         if self.general_settings[CONF_FAST_STATUS_CHANGE]:
             self._attr_is_closing = True
             self._attr_is_opening = False
-            self._attr_is_closed = None
+            self._attr_is_closed = False
 
             self.schedule_update_ha_state()
 
@@ -276,10 +278,6 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
                     self._attr_is_closed = False
                     self._attr_is_opening = False
                     self._attr_is_closing = False
-                else:
-                    self._attr_is_closed = False
-                    self._attr_is_opening = True
-                    self._attr_is_closing = True
 
             
             LOGGER.debug(f"[cover {self.dev_id}] state: {self.state}, opening: {self.is_opening}, closing: {self.is_closing}, closed: {self.is_closed}, position: {self.current_cover_position}")

--- a/custom_components/eltako/cover.py
+++ b/custom_components/eltako/cover.py
@@ -237,7 +237,7 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
             if decoded.state == 0x02: # down
                 self._attr_is_closing = True
                 self._attr_is_opening = False
-                self._attr_is_closed = None
+                self._attr_is_closed = False
             elif decoded.state == 0x50: # closed
                 self._attr_is_opening = False
                 self._attr_is_closing = False
@@ -246,11 +246,11 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
             elif decoded.state == 0x01: # up
                 self._attr_is_opening = True
                 self._attr_is_closing = False
-                self._attr_is_closed = None
+                self._attr_is_closed = False
             elif decoded.state == 0x70: # open
                 self._attr_is_opening = False
                 self._attr_is_closing = False
-                self._attr_is_closed = None
+                self._attr_is_closed = False
                 self._attr_current_cover_position = 100
             elif decoded.time is not None and decoded.direction is not None and self._time_closes is not None and self._time_opens is not None:
 

--- a/custom_components/eltako/cover.py
+++ b/custom_components/eltako/cover.py
@@ -222,7 +222,7 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
             return
         
         if self.dev_eep in [G5_3F_7F]:
-            LOGGER.debug(f"[cover {self.dev_id}] G5_3F_7F - {decoded}")
+            LOGGER.debug(f"[cover {self.dev_id}] G5_3F_7F - {decoded.__dict__}")
             if decoded.time is not None and decoded.direction is not None and self._time_closes is not None and self._time_opens is not None:
                 time_in_seconds = decoded.time / 10.0
                 

--- a/custom_components/eltako/cover.py
+++ b/custom_components/eltako/cover.py
@@ -97,11 +97,11 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
                 elif latest_state.state == STATE_CLOSING:
                     self._attr_is_opening = False
                     self._attr_is_closing = True
-                    self._attr_is_closed = False
+                    self._attr_is_closed = None
                 elif latest_state.state == STATE_OPENING:
                     self._attr_is_opening = True
                     self._attr_is_closing = False
-                    self._attr_is_closed = False
+                    self._attr_is_closed = None
             
         except Exception as e:
             self._attr_current_cover_position = None
@@ -225,6 +225,7 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
             if decoded.state == 0x02: # down
                 self._attr_is_closing = True
                 self._attr_is_opening = False
+                self._attr_is_closed = None
             elif decoded.state == 0x50: # closed
                 self._attr_is_opening = False
                 self._attr_is_closing = False
@@ -233,7 +234,7 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
             elif decoded.state == 0x01: # up
                 self._attr_is_opening = True
                 self._attr_is_closing = False
-                self._attr_is_closed = False
+                self._attr_is_closed = None
             elif decoded.state == 0x70: # open
                 self._attr_is_opening = False
                 self._attr_is_closing = False
@@ -248,8 +249,12 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
                 else: # down
                     self._attr_current_cover_position = max(self._attr_current_cover_position - int(time_in_seconds / self._time_closes * 100.0), 0)
                     
-                    if self._attr_current_cover_position == 0:
-                        self._attr_is_closed = True
+                if self._attr_current_cover_position == 0:
+                    self._attr_is_closed = True
+                elif self._attr_current_cover_position == 100:
+                    self._attr_is_closed = False
+                else:
+                    self._attr_is_closed = None
 
                 self._attr_is_closing = False
                 self._attr_is_opening = False

--- a/custom_components/eltako/datetime.py
+++ b/custom_components/eltako/datetime.py
@@ -80,7 +80,7 @@ class GatewayLastReceivedMessage(EltakoEntity, DateTimeEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Return the device info."""
+        """Return the device info."""   
         return DeviceInfo(
             identifiers={(DOMAIN, self.gateway.serial_path)},
             name= self.gateway.dev_name,

--- a/custom_components/eltako/datetime.py
+++ b/custom_components/eltako/datetime.py
@@ -47,6 +47,8 @@ async def async_setup_entry(
     log_entities_to_be_added(entities, platform)
     async_add_entities(entities)
 
+
+
 class GatewayLastReceivedMessage(EltakoEntity, DateTimeEntity):
     """Protocols last time when message received"""
 
@@ -60,6 +62,21 @@ class GatewayLastReceivedMessage(EltakoEntity, DateTimeEntity):
         self.gateway.set_last_message_received_handler(self.set_value)
 
         super().__init__(platform, gateway, gateway.base_id, gateway.dev_name, None)
+
+    def load_value_initially(self, latest_state:State):
+        try:
+            if 'unknown' == latest_state.state:
+                self._attr_native_value = None
+            else:
+                # e.g.: 2024-02-12T23:32:44+00:00
+                self._attr_native_value = datetime.strptime(latest_state.state, '%Y-%m-%dT%H:%M:%S%z:%f')
+            
+        except Exception as e:
+            self._attr_native_value = None
+            raise e
+        
+        self.schedule_update_ha_state()
+        LOGGER.debug(f"[datetime {self.dev_id}] value initially loaded: [native_value: {self.native_value}, state: {self.state}]")
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/eltako/datetime.py
+++ b/custom_components/eltako/datetime.py
@@ -1,15 +1,7 @@
 import datetime
-from homeassistant.components.datetime import (
-    DateTimeEntity
-)
 
-from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA,
-    SensorDeviceClass,
-    SensorEntity,
-    SensorEntityDescription,
-    SensorStateClass,
-)
+from homeassistant.components.datetime import DateTimeEntity
+from homeassistant.components.sensor import SensorDeviceClass
 
 from homeassistant.const import Platform
 from homeassistant import config_entries

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -47,7 +47,7 @@ class EltakoEntity(Entity):
         else:
             description_key = '_'+description_key
 
-        return f"{DOMAIN}_gw{gateway.dev_id}_{config_helpers.format_address(dev_id, '_')}{description_key}"
+        return f"{DOMAIN}_gw{gateway.dev_id}_{config_helpers.format_address(dev_id)}{description_key}"
 
     def _get_description_key(self, description_key:str=None):
         if description_key is not None:

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -151,7 +151,8 @@ class EltakoEntity(Entity):
         LOGGER.debug(f"[device] latest state - _attr_state {self._attr_state}")
         LOGGER.debug(f"[device] latest state - state {self.state}")
         LOGGER.debug(f"[device] latest state - super().state {super().state}")
-        LOGGER.debug(f"[device] latest state - super().state {super(BinarySensorEntity,self).state}")
+        if isinstance(self, BinarySensorEntity):
+            LOGGER.debug(f"[device] latest state - super().state {super(BinarySensorEntity,self).state}")
 
         LOGGER.debug(f"properties: {self.__dict__.keys()}")
 

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -47,7 +47,7 @@ class EltakoEntity(Entity):
         else:
             description_key = '_'+description_key
 
-        return f"{DOMAIN}_gw{gateway.dev_id}_{config_helpers.format_address(dev_id)}{description_key}".replace('-', '_')
+        return f"{DOMAIN}_gw{gateway.dev_id}_{config_helpers.format_address(dev_id)}{description_key}".replace('-', '_').lower()
 
     def _get_description_key(self, description_key:str=None):
         if description_key is not None:

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -22,7 +22,7 @@ class EltakoEntity(Entity):
     """Parent class for all entities associated with the Eltako component."""
     
     
-    def __init__(self, platform: str, gateway: EnOceanGateway, dev_id: AddressExpression, dev_name: str="Device", dev_eep: EEP=None, description_key:str=None):
+    def __init__(self, platform: str, gateway: EnOceanGateway, dev_id: AddressExpression, dev_name: str="Device", dev_eep: EEP=None):
         """Initialize the device."""
         self._attr_has_entity_name = True
         self._attr_should_poll = True
@@ -36,7 +36,7 @@ class EltakoEntity(Entity):
         self._attr_dev_eep = dev_eep
         self.listen_to_addresses = []
         self.listen_to_addresses.append(self.dev_id[0])
-        self.description_key = self._get_description_key(description_key)
+        self.description_key = self._get_description_key()
         self._attr_unique_id = EltakoEntity._get_identifier(self.gateway, self.dev_id, self.description_key)
         # self._attr_identifier = EltakoEntity._get_identifier(self.gateway, self.dev_id, self._get_description_key())
         self.entity_id = f"{self._attr_ha_platform}.{self._attr_unique_id}"
@@ -62,6 +62,7 @@ class EltakoEntity(Entity):
         if hasattr(self, 'entity_description') and self.entity_description is not None:
             if self.description_key is None:
                 self.description_key = self.entity_description.key
+
         return self.description_key
 
     @property

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -1,7 +1,6 @@
 """Representation of an Eltako device."""
 from datetime import datetime
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
 from eltakobus.message import ESP2Message, EltakoWrappedRPS, EltakoWrapped1BS, EltakoWrapped4BS, RPSMessage, Regular4BSMessage, Regular1BSMessage
 from eltakobus.util import AddressExpression
 from eltakobus.eep import EEP
@@ -10,10 +9,9 @@ from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.entity_platform import DATA_ENTITY_PLATFORM
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.const import Platform
-
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, dispatcher_send
 from homeassistant.helpers.entity import Entity
+from homeassistant.const import Platform
 
 from .const import *
 from .gateway import EnOceanGateway
@@ -107,52 +105,12 @@ class EltakoEntity(Entity):
 
 
     def load_value_initially(self, latest_state:State):
-        # cast state:str to actual value
-        attributs = latest_state.attributes
-        # LOGGER.debug(f"[device] eneity unique_id: {self.unique_id}")
-        # LOGGER.debug(f"[device] latest state - state: {latest_state.state}")
-        # LOGGER.debug(f"[device] latest state - attributes: {latest_state.attributes}")
-        try:
-            if 'unknown' == latest_state.state:
-                if hasattr(self, '_attr_is_on'):
-                    self._attr_is_on = None
-                elif hasattr(self, '_attr_native_value'):
-                    self._attr_native_value = None
-
-            elif hasattr(self, '_attr_is_on'):
-                self._attr_is_on = 'on' == latest_state.state
-                
-            elif attributs.get('state_class', None) == 'measurement':
-                if '.' in  latest_state.state:
-                    self._attr_native_value = float(latest_state.state)
-                else:
-                    self._attr_native_value = int(latest_state.state)
-
-            elif attributs.get('state_class', None) == 'total_increasing':
-                self._attr_native_value = int(latest_state.state)
-
-            elif attributs.get('device_class', None) == 'device_class':
-                # e.g.: 2024-02-12T23:32:44+00:00
-                self._attr_native_value = datetime.strptime(latest_state.state, '%Y-%m-%dT%H:%M:%S%z:%f')
-            
-        except Exception as e:
-            if hasattr(self, '_attr_is_on'):
-                self._attr_is_on = None
-            elif hasattr(self, '_attr_native_value'):
-                self._attr_native_value = None
-            raise e
+        """This function is implemented in the concrete devices classes"""
+        LOGGER.debug(f"[device] eneity unique_id: {self.unique_id}")
+        LOGGER.debug(f"[device] latest state - state: {latest_state.state}")
+        LOGGER.debug(f"[device] latest state - attributes: {latest_state.attributes}")
         
-        # if hasattr(self, '_attr_is_on'):
-        #     LOGGER.debug(f"[device] latest state - set {self._attr_is_on}")
-        # elif hasattr(self, '_attr_native_value'):
-        #     LOGGER.debug(f"[device] latest state - set {self._attr_native_value}")
-
-        # LOGGER.debug(f"[device] latest state - _attr_state {self._attr_state}")
-        # LOGGER.debug(f"[device] latest state - state {self.state}")
-
-        # LOGGER.debug(f"properties: {self.__dict__.keys()}")
-
-        self.schedule_update_ha_state()
+        LOGGER.warn(f"[device {self.dev_id}] DOES NOT HAVE AN IMPLEMENTATION FOR: load_value_initially()")
 
 
     def validate_dev_id(self) -> bool:
@@ -223,13 +181,13 @@ class EltakoEntity(Entity):
         dispatcher_send(self.hass, event_id, msg)
         
 
-def validate_actuators_dev_and_sender_id(entities:[EltakoEntity]):
+def validate_actuators_dev_and_sender_id(entities:list[EltakoEntity]):
     """Only call it for actuators."""
     for e in entities:
         e.validate_dev_id()
         e.validate_sender_id()
 
-def log_entities_to_be_added(entities:[EltakoEntity], platform:Platform) -> None:
+def log_entities_to_be_added(entities:list[EltakoEntity], platform:Platform) -> None:
     for e in entities:
         temp_eep = ""
         if e.dev_eep:

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -47,7 +47,7 @@ class EltakoEntity(Entity):
         else:
             description_key = '_'+description_key
 
-        return f"{DOMAIN}_gw{gateway.dev_id}_{config_helpers.format_address(dev_id)}{description_key}"
+        return f"{DOMAIN}_gw{gateway.dev_id}_{config_helpers.format_address(dev_id)}{description_key}".replace('-', '_')
 
     def _get_description_key(self, description_key:str=None):
         if description_key is not None:

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -36,8 +36,8 @@ class EltakoEntity(Entity):
         self._attr_dev_eep = dev_eep
         self.listen_to_addresses = []
         self.listen_to_addresses.append(self.dev_id[0])
-        self.description_key = self._get_description_key(description_key)
-        self._attr_unique_id = EltakoEntity._get_identifier(self.gateway, self.dev_id, self.description_key)
+        self.description_key = description_key
+        self._attr_unique_id = EltakoEntity._get_identifier(self.gateway, self.dev_id, self._get_description_key())
         # self._attr_identifier = EltakoEntity._get_identifier(self.gateway, self.dev_id, self._get_description_key())
         self.entity_id = f"{self._attr_ha_platform}.{self._attr_unique_id}"
 

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -22,7 +22,7 @@ class EltakoEntity(Entity):
     """Parent class for all entities associated with the Eltako component."""
     
     
-    def __init__(self, platform: str, gateway: EnOceanGateway, dev_id: AddressExpression, dev_name: str="Device", dev_eep: EEP=None):
+    def __init__(self, platform: str, gateway: EnOceanGateway, dev_id: AddressExpression, dev_name: str="Device", dev_eep: EEP=None, description_key:str=None):
         """Initialize the device."""
         self._attr_has_entity_name = True
         self._attr_should_poll = True
@@ -36,7 +36,7 @@ class EltakoEntity(Entity):
         self._attr_dev_eep = dev_eep
         self.listen_to_addresses = []
         self.listen_to_addresses.append(self.dev_id[0])
-        self.description_key = self._get_description_key()
+        self.description_key = self._get_description_key(description_key)
         self._attr_unique_id = EltakoEntity._get_identifier(self.gateway, self.dev_id, self.description_key)
         # self._attr_identifier = EltakoEntity._get_identifier(self.gateway, self.dev_id, self._get_description_key())
         self.entity_id = f"{self._attr_ha_platform}.{self._attr_unique_id}"
@@ -57,12 +57,11 @@ class EltakoEntity(Entity):
     def _get_description_key(self, description_key:str=None):
         if description_key is not None:
             self.description_key = description_key
-            return self.description_key
 
         if hasattr(self, 'entity_description') and self.entity_description is not None:
             if self.description_key is None:
                 self.description_key = self.entity_description.key
-
+                
         return self.description_key
 
     @property

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -121,7 +121,8 @@ class EltakoEntity(Entity):
 
             elif hasattr(self, '_attr_is_on'):
                 self._attr_is_on = 'on' == latest_state.state
-                self._attr_state = latest_state.state
+                super(self,BinarySensorEntity).self._attr_state = latest_state.state
+                super(self,Entity).self._attr_state = latest_state.state
 
             elif attributs.get('state_class', None) == 'measurement':
                 if '.' in  latest_state.state:
@@ -152,7 +153,7 @@ class EltakoEntity(Entity):
         LOGGER.debug(f"[device] latest state - state {self.state}")
         LOGGER.debug(f"[device] latest state - super().state {super().state}")
         if isinstance(self, BinarySensorEntity):
-            LOGGER.debug(f"[device] latest state - super().state {super(BinarySensorEntity,self).state}")
+            LOGGER.debug(f"[device] latest state - super(BinarySensorEntity).state {super(BinarySensorEntity,self).state}")
 
         LOGGER.debug(f"properties: {self.__dict__.keys()}")
 

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -150,6 +150,8 @@ class EltakoEntity(Entity):
         LOGGER.debug(f"[device] latest state - _attr_state {self._attr_state}")
         LOGGER.debug(f"[device] latest state - state {self.state}")
 
+        LOGGER.debug(f"properties: {self.__dict__.keys()}")
+
         self.schedule_update_ha_state()
 
 

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -121,6 +121,9 @@ class EltakoEntity(Entity):
             elif hasattr(self, '_attr_is_on'):
                 self._attr_is_on = 'on' == latest_state.state
                 self._attr_state = latest_state.state
+                def my_state():
+                    return 'on' if self._attr_is_on else 'off'
+                self.state = my_state
 
             elif attributs.get('state_class', None) == 'measurement':
                 if '.' in  latest_state.state:

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -109,9 +109,9 @@ class EltakoEntity(Entity):
     def load_value_initially(self, latest_state:State):
         # cast state:str to actual value
         attributs = latest_state.attributes
-        LOGGER.debug(f"[device] eneity unique_id: {self.unique_id}")
-        LOGGER.debug(f"[device] latest state - state: {latest_state.state}")
-        LOGGER.debug(f"[device] latest state - attributes: {latest_state.attributes}")
+        # LOGGER.debug(f"[device] eneity unique_id: {self.unique_id}")
+        # LOGGER.debug(f"[device] latest state - state: {latest_state.state}")
+        # LOGGER.debug(f"[device] latest state - attributes: {latest_state.attributes}")
         try:
             if 'unknown' == latest_state.state:
                 if hasattr(self, '_attr_is_on'):
@@ -142,15 +142,15 @@ class EltakoEntity(Entity):
                 self._attr_native_value = None
             raise e
         
-        if hasattr(self, '_attr_is_on'):
-            LOGGER.debug(f"[device] latest state - set {self._attr_is_on}")
-        elif hasattr(self, '_attr_native_value'):
-            LOGGER.debug(f"[device] latest state - set {self._attr_native_value}")
+        # if hasattr(self, '_attr_is_on'):
+        #     LOGGER.debug(f"[device] latest state - set {self._attr_is_on}")
+        # elif hasattr(self, '_attr_native_value'):
+        #     LOGGER.debug(f"[device] latest state - set {self._attr_native_value}")
 
-        LOGGER.debug(f"[device] latest state - _attr_state {self._attr_state}")
-        LOGGER.debug(f"[device] latest state - state {self.state}")
+        # LOGGER.debug(f"[device] latest state - _attr_state {self._attr_state}")
+        # LOGGER.debug(f"[device] latest state - state {self.state}")
 
-        LOGGER.debug(f"properties: {self.__dict__.keys()}")
+        # LOGGER.debug(f"properties: {self.__dict__.keys()}")
 
         self.schedule_update_ha_state()
 

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -38,11 +38,10 @@ class EltakoEntity(Entity):
         self.listen_to_addresses.append(self.dev_id[0])
         self.description_key = description_key
         self._attr_unique_id = EltakoEntity._get_identifier(self.gateway, self.dev_id, self._get_description_key())
-        # self._attr_identifier = EltakoEntity._get_identifier(self.gateway, self.dev_id, self._get_description_key())
         self.entity_id = f"{self._attr_ha_platform}.{self._attr_unique_id}"
 
     @classmethod
-    def _get_unique_id(cls, gateway: EnOceanGateway, dev_id: AddressExpression, description_key:str=None) -> str:
+    def _get_unique_id(cls, gateway: EnOceanGateway, dev_id: AddressExpression) -> str:
         return f"{DOMAIN}_gw{gateway.dev_id}_{config_helpers.format_address(dev_id)}"
 
     @classmethod

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -121,9 +121,7 @@ class EltakoEntity(Entity):
 
             elif hasattr(self, '_attr_is_on'):
                 self._attr_is_on = 'on' == latest_state.state
-                super(self,BinarySensorEntity).self._attr_state = latest_state.state
-                super(self,Entity).self._attr_state = latest_state.state
-
+                
             elif attributs.get('state_class', None) == 'measurement':
                 if '.' in  latest_state.state:
                     self._attr_native_value = float(latest_state.state)
@@ -151,9 +149,6 @@ class EltakoEntity(Entity):
 
         LOGGER.debug(f"[device] latest state - _attr_state {self._attr_state}")
         LOGGER.debug(f"[device] latest state - state {self.state}")
-        LOGGER.debug(f"[device] latest state - super().state {super().state}")
-        if isinstance(self, BinarySensorEntity):
-            LOGGER.debug(f"[device] latest state - super(BinarySensorEntity).state {super(BinarySensorEntity,self).state}")
 
         LOGGER.debug(f"properties: {self.__dict__.keys()}")
 

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -41,17 +41,13 @@ class EltakoEntity(Entity):
         self.entity_id = f"{self._attr_ha_platform}.{self._attr_unique_id}"
 
     @classmethod
-    def _get_unique_id(cls, gateway: EnOceanGateway, dev_id: AddressExpression) -> str:
-        return f"{DOMAIN}_gw{gateway.dev_id}_{config_helpers.format_address(dev_id)}"
-
-    @classmethod
     def _get_identifier(cls, gateway: EnOceanGateway, dev_id: AddressExpression, description_key:str=None) -> str:
         if description_key is None:
             description_key = ''
         else:
             description_key = '_'+description_key
 
-        return f"{DOMAIN}_gw{gateway.dev_id}_{config_helpers.format_address(dev_id)}{description_key}"
+        return f"{DOMAIN}_gw{gateway.dev_id}_{config_helpers.format_address(dev_id, '_')}{description_key}"
 
     def _get_description_key(self, description_key:str=None):
         if description_key is not None:

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -147,8 +147,8 @@ class EltakoEntity(Entity):
         elif hasattr(self, '_attr_native_value'):
             LOGGER.debug(f"[device] latest state - set {self._attr_native_value}")
 
+        LOGGER.debug(f"[device] latest state - _attr_state {self._attr_state}")
         LOGGER.debug(f"[device] latest state - state {self.state}")
-        LOGGER.debug(f"[device] latest state - platform {self.platform}")
 
         self.schedule_update_ha_state()
 

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -22,7 +22,7 @@ class EltakoEntity(Entity):
     """Parent class for all entities associated with the Eltako component."""
     
     
-    def __init__(self, platform: str, gateway: EnOceanGateway, dev_id: AddressExpression, dev_name: str="Device", dev_eep: EEP=None):
+    def __init__(self, platform: str, gateway: EnOceanGateway, dev_id: AddressExpression, dev_name: str="Device", dev_eep: EEP=None, description_key:str=None):
         """Initialize the device."""
         self._attr_has_entity_name = True
         self._attr_should_poll = True
@@ -36,8 +36,8 @@ class EltakoEntity(Entity):
         self._attr_dev_eep = dev_eep
         self.listen_to_addresses = []
         self.listen_to_addresses.append(self.dev_id[0])
-        self.description_key = None
-        self._attr_unique_id = EltakoEntity._get_identifier(self.gateway, self.dev_id, self._get_description_key())
+        self.description_key = self._get_description_key(description_key)
+        self._attr_unique_id = EltakoEntity._get_identifier(self.gateway, self.dev_id, self.description_key)
         # self._attr_identifier = EltakoEntity._get_identifier(self.gateway, self.dev_id, self._get_description_key())
         self.entity_id = f"{self._attr_ha_platform}.{self._attr_unique_id}"
 
@@ -54,8 +54,9 @@ class EltakoEntity(Entity):
 
         return f"{DOMAIN}_gw{gateway.dev_id}_{config_helpers.format_address(dev_id)}{description_key}"
 
-    def _get_description_key(self):
-        if self.description_key is not None:
+    def _get_description_key(self, description_key:str=None):
+        if description_key is not None:
+            self.description_key = description_key
             return self.description_key
 
         if hasattr(self, 'entity_description') and self.entity_description is not None:

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -1,6 +1,7 @@
 """Representation of an Eltako device."""
 from datetime import datetime
 
+from homeassistant.components.binary_sensor import BinarySensorEntity
 from eltakobus.message import ESP2Message, EltakoWrappedRPS, EltakoWrapped1BS, EltakoWrapped4BS, RPSMessage, Regular4BSMessage, Regular1BSMessage
 from eltakobus.util import AddressExpression
 from eltakobus.eep import EEP
@@ -121,9 +122,6 @@ class EltakoEntity(Entity):
             elif hasattr(self, '_attr_is_on'):
                 self._attr_is_on = 'on' == latest_state.state
                 self._attr_state = latest_state.state
-                def my_state():
-                    return 'on' if self._attr_is_on else 'off'
-                self.state = my_state
 
             elif attributs.get('state_class', None) == 'measurement':
                 if '.' in  latest_state.state:
@@ -152,6 +150,8 @@ class EltakoEntity(Entity):
 
         LOGGER.debug(f"[device] latest state - _attr_state {self._attr_state}")
         LOGGER.debug(f"[device] latest state - state {self.state}")
+        LOGGER.debug(f"[device] latest state - super().state {super().state}")
+        LOGGER.debug(f"[device] latest state - super().state {super(BinarySensorEntity,self).state}")
 
         LOGGER.debug(f"properties: {self.__dict__.keys()}")
 

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -106,12 +106,10 @@ class EltakoEntity(Entity):
 
     def load_value_initially(self, latest_state:State):
         """This function is implemented in the concrete devices classes"""
-        LOGGER.debug(f"[device] eneity unique_id: {self.unique_id}")
-        LOGGER.debug(f"[device] latest state - state: {latest_state.state}")
-        LOGGER.debug(f"[device] latest state - attributes: {latest_state.attributes}")
+        LOGGER.warn(f"[{self._attr_ha_platform} {self.dev_id}] DOES NOT HAVE AN IMPLEMENTATION FOR: load_value_initially()")
+        LOGGER.debug(f"[{self._attr_ha_platform} {self.dev_id}] latest state - state: {latest_state.state}")
+        LOGGER.debug(f"[{self._attr_ha_platform} {self.dev_id}] latest state - attributes: {latest_state.attributes}")
         
-        LOGGER.warn(f"[device {self.dev_id}] DOES NOT HAVE AN IMPLEMENTATION FOR: load_value_initially()")
-
 
     def validate_dev_id(self) -> bool:
         return self.gateway.validate_dev_id(self.dev_id, self.dev_name)

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -68,8 +68,9 @@ def get_device_config_for_gateway(hass: HomeAssistant, config_entry: ConfigEntry
 
 def cleanup_unavailable_entities(hass: HomeAssistant):
     # for p in pl.async_get_platforms(hass, DOMAIN):
-    for e in pl.async_get_current_platform().entities:
-        LOGGER.debug(f"ENTITY {e} IN PLATFORM {p.platform_name}")
+    # cur_pl = pl.async_get_current_platform()
+    # for e in cur_pl.entities:
+    #     LOGGER.debug(f"ENTITY {e} IN PLATFORM {cur_pl.platform_name} {cur_pl.}")
 
     entity_registry = er.async_get(hass)
     for key, e in entity_registry.entities.items():

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -74,16 +74,18 @@ def cleanup_unavailable_entities(hass: HomeAssistant):
 
     device_reg = dr.async_get(hass)
     for key, d in device_reg.devices.items():
-        LOGGER.debug(f"DEVICE ===>>> key: {key}, id: {d.id}, name: {d.name}, area id: {d.area_id}")
-        device_reg.async_get_device
+        LOGGER.debug(f"DEVICE ===>>> key: {key}, id: {d.id}, name: {d.name}, area id: {d.area_id} domain: {d.identifiers[0][0]}")
 
     entity_registry = er.async_get(hass)
     for key, e in entity_registry.entities.items():
-        # if DOMAIN == e.platform:
-        LOGGER.debug(f"ENTITY ===>>> key: {key}, id: {e.entity_id}, name: {e.name}, platform: {e.platform}, domain: {e.domain}")
+        if DOMAIN == e.platform:
+            LOGGER.debug(f"ENTITY ===>>> key: {key}, id: {e.entity_id}, name: {e.name}, platform: {e.platform}, domain: {e.domain}")
 
 
-    dr.async_cleanup(hass, device_reg, entity_registry)
+    for e in hass.config_entries.async_entries():
+        LOGGER.debug(f"CONFIG ENTRIES: entry_id {e.entry_id}, unique_id: {e.unique_id}")
+
+    # dr.async_cleanup(hass, device_reg, entity_registry)
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -85,7 +85,7 @@ def cleanup_unavailable_entities(hass: HomeAssistant):
     for e in hass.config_entries.async_entries():
         LOGGER.debug(f"CONFIG ENTRIES: entry_id {e.entry_id}, unique_id: {e.unique_id}, title: {e.title}, domain: {e.domain}")
         for key, d in e.data.items():
-            LOGGER.debug(f"CONF ENTR DATA: key: {key} => {d.__dict__}")
+            LOGGER.debug(f"CONF ENTR DATA: key: {key} => {d}")
 
 
     dr.async_cleanup(hass, device_reg, entity_registry)

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -2,6 +2,7 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.reload import async_reload_integration_platforms
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er, device_registry as dr, entity_platform as pl
 
@@ -66,7 +67,7 @@ def get_device_config_for_gateway(hass: HomeAssistant, config_entry: ConfigEntry
     return config_helpers.get_device_config(hass.data[DATA_ELTAKO][ELTAKO_CONFIG], gateway.dev_id)
 
 
-def cleanup_unavailable_entities(hass: HomeAssistant):
+def cleanup_unavailable_entities(hass: HomeAssistant, config_entry: ConfigEntry):
     # for p in pl.async_get_platforms(hass, DOMAIN):
     # cur_pl = pl.async_get_current_platform()
     # for e in cur_pl.entities:
@@ -87,8 +88,7 @@ def cleanup_unavailable_entities(hass: HomeAssistant):
         for key, d in e.data.items():
             LOGGER.debug(f"CONF ENTR DATA: key: {key} => {d}")
 
-
-    dr.async_cleanup(hass, device_reg, entity_registry)
+    async_reload_integration_platforms(hass, DOMAIN, PLATFORMS)
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -74,8 +74,8 @@ def cleanup_unavailable_entities(hass: HomeAssistant):
 
     entity_registry = er.async_get(hass)
     for key, e in entity_registry.entities.items():
-        if DOMAIN == e.platform:
-            LOGGER.debug(f"ENTITY ===>>> key: {key}, id: {e.entity_id}, name: {e.name}, platform: {e.platform}, domain: {e.domain}")
+        # if DOMAIN == e.platform:
+        LOGGER.debug(f"ENTITY ===>>> key: {key}, id: {e.entity_id}, name: {e.name}, platform: {e.platform}, domain: {e.domain}")
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -83,7 +83,10 @@ def cleanup_unavailable_entities(hass: HomeAssistant):
 
 
     for e in hass.config_entries.async_entries():
-        LOGGER.debug(f"CONFIG ENTRIES: entry_id {e.entry_id}, unique_id: {e.unique_id}")
+        LOGGER.debug(f"CONFIG ENTRIES: entry_id {e.entry_id}, unique_id: {e.unique_id}, title: {e.title}, domain: {e.domain}")
+        for key, d in e.data.items():
+            LOGGER.debug(f"CONF ENTR DATA: key: {key} => {d.__dict__}")
+
 
     dr.async_cleanup(hass, device_reg, entity_registry)
 

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -69,7 +69,8 @@ def get_device_config_for_gateway(hass: HomeAssistant, config_entry: ConfigEntry
 def cleanup_unavailable_entities(hass: HomeAssistant):
     entity_registry = er.async_get(hass)
     for key, e in entity_registry.entities.items():
-        LOGGER.debug(f"Entity: key: {key}, id: {e.entity_id}, name: {e.name}, platform: {e.platform}, domain: {e.domain}, disabled: {e.disabled}")
+        if DOMAIN == e.platform:
+            LOGGER.debug(f"ENTITY ===>>> key: {key}, id: {e.entity_id}, name: {e.name}, platform: {e.platform}, domain: {e.domain}")
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -67,30 +67,6 @@ def get_device_config_for_gateway(hass: HomeAssistant, config_entry: ConfigEntry
     return config_helpers.get_device_config(hass.data[DATA_ELTAKO][ELTAKO_CONFIG], gateway.dev_id)
 
 
-async def cleanup_unavailable_entities(hass: HomeAssistant, config_entry: ConfigEntry):
-    # for p in pl.async_get_platforms(hass, DOMAIN):
-    # cur_pl = pl.async_get_current_platform()
-    # for e in cur_pl.entities:
-    #     LOGGER.debug(f"ENTITY {e} IN PLATFORM {cur_pl.platform_name} {cur_pl.}")
-
-    device_reg = dr.async_get(hass)
-    for key, d in device_reg.devices.items():
-        LOGGER.debug(f"DEVICE ===>>> key: {key}, id: {d.id}, name: {d.name}, area id: {d.area_id} domain: {d.identifiers}")
-
-    entity_registry = er.async_get(hass)
-    for key, e in entity_registry.entities.items():
-        if DOMAIN == e.platform:
-            LOGGER.debug(f"ENTITY ===>>> key: {key}, id: {e.entity_id}, name: {e.name}, platform: {e.platform}, domain: {e.domain}")
-
-
-    for e in hass.config_entries.async_entries():
-        LOGGER.debug(f"CONFIG ENTRIES: entry_id {e.entry_id}, unique_id: {e.unique_id}, title: {e.title}, domain: {e.domain}")
-        for key, d in e.data.items():
-            LOGGER.debug(f"CONF ENTR DATA: key: {key} => {d}")
-
-    await async_reload_integration_platforms(hass, DOMAIN, PLATFORMS)
-
-
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up an Eltako gateway for the given entry."""
     LOGGER.info(f"[{LOG_PREFIX}] Start gateway setup.")
@@ -160,8 +136,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(config_entry, platform)
         )
-
-    await cleanup_unavailable_entities(hass, config_entry)
 
     return True
 

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -74,7 +74,7 @@ def cleanup_unavailable_entities(hass: HomeAssistant):
 
     device_reg = dr.async_get(hass)
     for key, d in device_reg.devices.items():
-        LOGGER.debug(f"DEVICE ===>>> key: {key}, id: {d.id}, name: {d.name}, area id: {d.area_id} domain: {d.identifiers[0][0]}")
+        LOGGER.debug(f"DEVICE ===>>> key: {key}, id: {d.id}, name: {d.name}, area id: {d.area_id} domain: {d.identifiers}")
 
     entity_registry = er.async_get(hass)
     for key, e in entity_registry.entities.items():

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -67,9 +67,9 @@ def get_device_config_for_gateway(hass: HomeAssistant, config_entry: ConfigEntry
 
 
 def cleanup_unavailable_entities(hass: HomeAssistant):
-    for p in pl.async_get_platforms(hass, DOMAIN):
-        for e in p.entities:
-            LOGGER.debug(f"ENTITY {e} IN PLATFORM {p.platform_name}")
+    # for p in pl.async_get_platforms(hass, DOMAIN):
+    for e in pl.async_get_current_platform().entities:
+        LOGGER.debug(f"ENTITY {e} IN PLATFORM {p.platform_name}")
 
     entity_registry = er.async_get(hass)
     for key, e in entity_registry.entities.items():

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -85,7 +85,7 @@ def cleanup_unavailable_entities(hass: HomeAssistant):
     for e in hass.config_entries.async_entries():
         LOGGER.debug(f"CONFIG ENTRIES: entry_id {e.entry_id}, unique_id: {e.unique_id}")
 
-    # dr.async_cleanup(hass, device_reg, entity_registry)
+    dr.async_cleanup(hass, device_reg, entity_registry)
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -152,13 +152,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     await usb_gateway.async_setup()
     set_gateway_to_hass(hass, usb_gateway)
 
-    cleanup_unavailable_entities(hass)
-    
     hass.data[DATA_ELTAKO][DATA_ENTITIES] = {}
     for platform in PLATFORMS:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(config_entry, platform)
         )
+
+    cleanup_unavailable_entities(hass)
 
     return True
 

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -161,7 +161,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             hass.config_entries.async_forward_entry_setup(config_entry, platform)
         )
 
-    cleanup_unavailable_entities(hass)
+    cleanup_unavailable_entities(hass, config_entry)
 
     return True
 

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -72,10 +72,18 @@ def cleanup_unavailable_entities(hass: HomeAssistant):
     # for e in cur_pl.entities:
     #     LOGGER.debug(f"ENTITY {e} IN PLATFORM {cur_pl.platform_name} {cur_pl.}")
 
+    device_reg = dr.async_get(hass)
+    for key, d in device_reg.devices.items():
+        LOGGER.debug(f"DEVICE ===>>> key: {key}, id: {d.id}, name: {d.name}, area id: {d.area_id}")
+        device_reg.async_get_device
+
     entity_registry = er.async_get(hass)
     for key, e in entity_registry.entities.items():
         # if DOMAIN == e.platform:
         LOGGER.debug(f"ENTITY ===>>> key: {key}, id: {e.entity_id}, name: {e.name}, platform: {e.platform}, domain: {e.domain}")
+
+
+    dr.async_cleanup(hass, device_reg, entity_registry)
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -67,7 +67,7 @@ def get_device_config_for_gateway(hass: HomeAssistant, config_entry: ConfigEntry
     return config_helpers.get_device_config(hass.data[DATA_ELTAKO][ELTAKO_CONFIG], gateway.dev_id)
 
 
-def cleanup_unavailable_entities(hass: HomeAssistant, config_entry: ConfigEntry):
+async def cleanup_unavailable_entities(hass: HomeAssistant, config_entry: ConfigEntry):
     # for p in pl.async_get_platforms(hass, DOMAIN):
     # cur_pl = pl.async_get_current_platform()
     # for e in cur_pl.entities:
@@ -88,7 +88,7 @@ def cleanup_unavailable_entities(hass: HomeAssistant, config_entry: ConfigEntry)
         for key, d in e.data.items():
             LOGGER.debug(f"CONF ENTR DATA: key: {key} => {d}")
 
-    async_reload_integration_platforms(hass, DOMAIN, PLATFORMS)
+    await async_reload_integration_platforms(hass, DOMAIN, PLATFORMS)
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -161,7 +161,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             hass.config_entries.async_forward_entry_setup(config_entry, platform)
         )
 
-    cleanup_unavailable_entities(hass, config_entry)
+    await cleanup_unavailable_entities(hass, config_entry)
 
     return True
 

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -3,7 +3,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er, device_registry as dr
+from homeassistant.helpers import entity_registry as er, device_registry as dr, entity_platform as pl
 
 from .const import *
 from .schema import CONFIG_SCHEMA
@@ -67,6 +67,10 @@ def get_device_config_for_gateway(hass: HomeAssistant, config_entry: ConfigEntry
 
 
 def cleanup_unavailable_entities(hass: HomeAssistant):
+    for p in pl.async_get_platforms(hass, DOMAIN):
+        for e in p.entities:
+            LOGGER.debug(f"ENTITY {e} IN PLATFORM {p.platform_name}")
+
     entity_registry = er.async_get(hass)
     for key, e in entity_registry.entities.items():
         if DOMAIN == e.platform:

--- a/custom_components/eltako/gateway.py
+++ b/custom_components/eltako/gateway.py
@@ -133,7 +133,7 @@ class EnOceanGateway:
         device_registry.async_get_or_create(
             config_entry_id=self.config_entry_id,
             identifiers={(DOMAIN, self.serial_path)},
-            connections={(CONF_MAC, config_helpers.format_address(self.base_id))},
+            # connections={(CONF_MAC, config_helpers.format_address(self.base_id))},
             manufacturer=MANUFACTURER,
             name= self.dev_name,
             model=self.model,

--- a/custom_components/eltako/gateway.py
+++ b/custom_components/eltako/gateway.py
@@ -123,10 +123,6 @@ class EnOceanGateway:
 
         self._bus.set_status_changed_handler(self._fire_connection_state_changed_event)
 
-    # def get_device_info(self) -> DeviceInfo:
-    #     """Return the device info."""
-    #     device_registry = dr.async_get(self.hass)
-    #     return device_registry.async_get(self.config_entry_id)
 
     def _register_device(self) -> None:
         device_registry = dr.async_get(self.hass)

--- a/custom_components/eltako/light.py
+++ b/custom_components/eltako/light.py
@@ -81,7 +81,7 @@ class AbstractLightEntity(EltakoEntity, LightEntity, RestoreEntity):
         
         self.schedule_update_ha_state()
 
-        LOGGER.debug(f"[light {self.dev_id}] value initially loaded: [is_on: {self.is_on}, state: {self.state}]")
+        LOGGER.debug(f"[light {self.dev_id}] value initially loaded: [is_on: {self.is_on}, brightness: {self.brightness}, state: {self.state}]")
 
 class EltakoDimmableLight(AbstractLightEntity):
     """Representation of an Eltako light source."""

--- a/custom_components/eltako/light.py
+++ b/custom_components/eltako/light.py
@@ -72,6 +72,8 @@ class AbstractLightEntity(EltakoEntity, LightEntity, RestoreEntity):
                     self._attr_is_on = 'on' == latest_state.state
                 else:
                     self._attr_is_on = None
+
+                self._attr_brightness = latest_state.attributes.get('brightness', None)
                 
         except Exception as e:
             self._attr_is_on = None

--- a/custom_components/eltako/light.py
+++ b/custom_components/eltako/light.py
@@ -62,6 +62,8 @@ async def async_setup_entry(
 class AbstractLightEntity(EltakoEntity, LightEntity, RestoreEntity):
 
     def load_value_initially(self, latest_state:State):
+        LOGGER.debug(f"[{self._attr_ha_platform} {self.dev_id}] latest state - state: {latest_state.state}")
+        LOGGER.debug(f"[{self._attr_ha_platform} {self.dev_id}] latest state - attributes: {latest_state.attributes}")
         try:
             if 'unknown' == latest_state.state:
                 self._attr_is_on = None

--- a/custom_components/eltako/light.py
+++ b/custom_components/eltako/light.py
@@ -68,15 +68,9 @@ class EltakoDimmableLight(EltakoEntity, LightEntity):
     def __init__(self, platform:str, gateway: EnOceanGateway, dev_id: AddressExpression, dev_name: str, dev_eep: EEP, sender_id: AddressExpression, sender_eep: EEP):
         """Initialize the Eltako light source."""
         super().__init__(platform, gateway, dev_id, dev_name, dev_eep)
-        self._on_state = False
-        self._attr_brightness = 50
         self._sender_id = sender_id
         self._sender_eep = sender_eep
 
-    @property
-    def is_on(self):
-        """If light is on."""
-        return self._on_state
     
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the light source on or sets a specific dimmer value."""
@@ -90,7 +84,7 @@ class EltakoDimmableLight(EltakoEntity, LightEntity):
             self.send_message(msg)
         
         if self.general_settings[CONF_FAST_STATUS_CHANGE]:
-            self._on_state = True
+            self._attr_is_on = True
             self.schedule_update_ha_state()
 
 
@@ -105,7 +99,7 @@ class EltakoDimmableLight(EltakoEntity, LightEntity):
             
         if self.general_settings[CONF_FAST_STATUS_CHANGE]:
             self._attr_brightness = 0
-            self._on_state = False
+            self._attr_is_on = False
             self.schedule_update_ha_state()
 
 
@@ -131,7 +125,7 @@ class EltakoDimmableLight(EltakoEntity, LightEntity):
                 if decoded.switching.learn_button != 1:
                     return
                     
-                self._on_state = decoded.switching.switching_command
+                self._attr_is_on = decoded.switching.switching_command
             elif decoded.command == 0x02:
                 if decoded.dimming.learn_button != 1:
                     return
@@ -141,7 +135,7 @@ class EltakoDimmableLight(EltakoEntity, LightEntity):
                 elif decoded.dimming.dimming_range == 1:
                     self._attr_brightness = decoded.dimming.dimming_value
 
-                self._on_state = decoded.dimming.switching_command
+                self._attr_is_on = decoded.dimming.switching_command
             else:
                 return
 
@@ -157,14 +151,9 @@ class EltakoSwitchableLight(EltakoEntity, LightEntity):
     def __init__(self, platform: str, gateway: EnOceanGateway, dev_id: AddressExpression, dev_name: str, dev_eep: EEP, sender_id: AddressExpression, sender_eep: EEP):
         """Initialize the Eltako light source."""
         super().__init__(platform, gateway, dev_id, dev_name, dev_eep)
-        self._on_state = False
         self._sender_id = sender_id
         self._sender_eep = sender_eep
 
-    @property
-    def is_on(self):
-        """If light is on."""
-        return self._on_state
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the light source on or sets a specific dimmer value."""
@@ -176,7 +165,7 @@ class EltakoSwitchableLight(EltakoEntity, LightEntity):
             self.send_message(msg)
 
         if self.general_settings[CONF_FAST_STATUS_CHANGE]:
-            self._on_state = True
+            self._attr_is_on = True
             self.schedule_update_ha_state()
         
 
@@ -190,7 +179,7 @@ class EltakoSwitchableLight(EltakoEntity, LightEntity):
             self.send_message(msg)
         
         if self.general_settings[CONF_FAST_STATUS_CHANGE]:
-            self._on_state = False
+            self._attr_is_on = False
             self.schedule_update_ha_state()
 
 
@@ -203,5 +192,5 @@ class EltakoSwitchableLight(EltakoEntity, LightEntity):
             return
 
         if self.dev_eep in [M5_38_08]:
-            self._on_state = decoded.state
+            self._attr_is_on = decoded.state
             self.schedule_update_ha_state()

--- a/custom_components/eltako/light.py
+++ b/custom_components/eltako/light.py
@@ -62,8 +62,8 @@ async def async_setup_entry(
 class AbstractLightEntity(EltakoEntity, LightEntity, RestoreEntity):
 
     def load_value_initially(self, latest_state:State):
-        LOGGER.debug(f"[{self._attr_ha_platform} {self.dev_id}] latest state - state: {latest_state.state}")
-        LOGGER.debug(f"[{self._attr_ha_platform} {self.dev_id}] latest state - attributes: {latest_state.attributes}")
+        # LOGGER.debug(f"[{self._attr_ha_platform} {self.dev_id}] latest state - state: {latest_state.state}")
+        # LOGGER.debug(f"[{self._attr_ha_platform} {self.dev_id}] latest state - attributes: {latest_state.attributes}")
         try:
             if 'unknown' == latest_state.state:
                 self._attr_is_on = None

--- a/custom_components/eltako/light.py
+++ b/custom_components/eltako/light.py
@@ -94,16 +94,17 @@ class EltakoDimmableLight(AbstractLightEntity):
     
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the light source on or sets a specific dimmer value."""
-        self._attr_brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+        brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
         
         address, _ = self._sender_id
         
         if self._sender_eep == A5_38_08:
-            dimming = CentralCommandDimming(int(self.brightness / 255.0 * 100.0), 0, 1, 0, 0, 1)
+            dimming = CentralCommandDimming(int(brightness / 255.0 * 100.0), 0, 1, 0, 0, 1)
             msg = A5_38_08(command=0x02, dimming=dimming).encode_message(address)
             self.send_message(msg)
         
         if self.general_settings[CONF_FAST_STATUS_CHANGE]:
+            self._attr_brightness = brightness
             self._attr_is_on = True
             self.schedule_update_ha_state()
 
@@ -131,7 +132,7 @@ class EltakoDimmableLight(AbstractLightEntity):
         """
         try:
             if msg.org == 0x07:
-                decoded = self.dev_eep.decode_message(msg)
+                decoded:A5_38_08 = self.dev_eep.decode_message(msg)
             elif msg.org == 0x05:
                 LOGGER.debug("[Dimmable Light] Ignore on/off message with org=0x05")
                 return

--- a/custom_components/eltako/sensor.py
+++ b/custom_components/eltako/sensor.py
@@ -410,9 +410,9 @@ class EltakoSensor(EltakoEntity, RestoreEntity, SensorEntity):
         return self.entity_description.name
 
     def load_value_initially(self, latest_state:State):
-        LOGGER.debug(f"[device] eneity unique_id: {self.unique_id}")
-        LOGGER.debug(f"[device] latest state - state: {latest_state.state}")
-        LOGGER.debug(f"[device] latest state - attributes: {latest_state.attributes}")
+        LOGGER.debug(f"[{self._attr_ha_platform} {self.dev_id}] eneity unique_id: {self.unique_id}")
+        LOGGER.debug(f"[{self._attr_ha_platform} {self.dev_id}] latest state - state: {latest_state.state}")
+        LOGGER.debug(f"[{self._attr_ha_platform} {self.dev_id}] latest state - attributes: {latest_state.attributes}")
         try:
             if 'unknown' == latest_state.state:
                 self._attr_is_on = None
@@ -441,7 +441,7 @@ class EltakoSensor(EltakoEntity, RestoreEntity, SensorEntity):
         
         self.schedule_update_ha_state()
 
-        LOGGER.debug(f"[sensor {self.dev_id} ({type(self).__name__})] value initially loaded: [native_value: {self.native_value}, state: {self.state}]")        
+        LOGGER.debug(f"[{self._attr_ha_platform} {self.dev_id} ({type(self).__name__})] value initially loaded: [native_value: {self.native_value}, state: {self.state}]")        
 
 class EltakoPirSensor(EltakoSensor):
     """Occupancy Sensor"""

--- a/custom_components/eltako/switch.py
+++ b/custom_components/eltako/switch.py
@@ -61,6 +61,23 @@ class EltakoSwitch(EltakoEntity, SwitchEntity, RestoreEntity):
         self._sender_id = sender_id
         self._sender_eep = sender_eep
         
+    def load_value_initially(self, latest_state:State):
+        try:
+            if 'unknown' == latest_state.state:
+                self._attr_is_on = None
+            else:
+                if latest_state.state in ['on', 'off']:
+                    self._attr_is_on = 'on' == latest_state.state
+                else:
+                    self._attr_is_on = None
+                
+        except Exception as e:
+            self._attr_is_on = None
+            raise e
+        
+        self.schedule_update_ha_state()
+
+        LOGGER.debug(f"[switch {self.dev_id}] value initially loaded: [is_on: {self.is_on}, state: {self.state}]")
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""

--- a/custom_components/eltako/switch.py
+++ b/custom_components/eltako/switch.py
@@ -7,13 +7,11 @@ from eltakobus.util import AddressExpression
 from eltakobus.eep import *
 
 from homeassistant import config_entries
-from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
-from homeassistant.const import CONF_ID, CONF_NAME, Platform
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.typing import ConfigType
 
 from . import config_helpers, get_gateway_from_hass, get_device_config_for_gateway
 from .config_helpers import DeviceConf

--- a/custom_components/eltako/switch.py
+++ b/custom_components/eltako/switch.py
@@ -60,12 +60,7 @@ class EltakoSwitch(EltakoEntity, SwitchEntity, RestoreEntity):
         super().__init__(platform, gateway, dev_id, dev_name, dev_eep)
         self._sender_id = sender_id
         self._sender_eep = sender_eep
-        self._on_state = False
         
-    @property
-    def is_on(self):
-        """Return whether the switch is on or off."""
-        return self._on_state
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
@@ -91,7 +86,7 @@ class EltakoSwitch(EltakoEntity, SwitchEntity, RestoreEntity):
             self.send_message(msg)
         
         if self.general_settings[CONF_FAST_STATUS_CHANGE]:
-            self._on_state = True
+            self._attr_is_on = True
             self.schedule_update_ha_state()
 
 
@@ -119,7 +114,7 @@ class EltakoSwitch(EltakoEntity, SwitchEntity, RestoreEntity):
             self.send_message(msg)
 
         if self.general_settings[CONF_FAST_STATUS_CHANGE]:
-            self._on_state = False
+            self._attr_is_on = False
             self.schedule_update_ha_state()
 
 
@@ -132,7 +127,7 @@ class EltakoSwitch(EltakoEntity, SwitchEntity, RestoreEntity):
             return
 
         if self.dev_eep in [M5_38_08]:
-            self._on_state = decoded.state
+            self._attr_is_on = decoded.state
             self.schedule_update_ha_state()
 
         elif self.dev_eep in [F6_02_01, F6_02_02]:
@@ -143,5 +138,5 @@ class EltakoSwitch(EltakoEntity, SwitchEntity, RestoreEntity):
             button_filter |= self.dev_id[1] is not None and self.dev_id[1] == 'right' and decoded.rocker_first_action == 3
             
             if button_filter and decoded.energy_bow:
-                self._on_state = not self._on_state
+                self._attr_is_on = not self._attr_is_on
                 self.schedule_update_ha_state()

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -122,3 +122,30 @@ class TestBinarySensor(unittest.TestCase):
         msg.data = b'\x00\x96\x0A\x09'
         bs.value_changed(msg)
         self.assertEqual(bs._attr_is_on, False)
+
+    def test_initial_loading_on(self):
+        bs = self.create_binary_sensor()
+        bs._attr_is_on = None
+
+        bs.load_value_initially(LatestStateMock('on'))
+        self.assertTrue(bs._attr_is_on)
+        self.assertTrue(bs.is_on)
+        self.assertEquals(bs.state, 'on')
+
+    def test_initial_loading_off(self):
+        bs = self.create_binary_sensor()
+        bs._attr_is_on = None
+
+        bs.load_value_initially(LatestStateMock('off'))
+        self.assertFalse(bs._attr_is_on)
+        self.assertFalse(bs.is_on)
+        self.assertEquals(bs.state, 'off')
+
+    def test_initial_loading_None(self):
+        bs = self.create_binary_sensor()
+        bs._attr_is_on = True
+
+        bs.load_value_initially(LatestStateMock('bla'))
+        self.assertIsNone(bs._attr_is_on)
+        self.assertIsNone(bs.is_on)
+        self.assertIsNone(bs.state)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -12,6 +12,7 @@ from eltakobus import *
 
 # mock update of Home Assistant
 Entity.schedule_update_ha_state = mock.Mock(return_value=None)
+ClimateController.schedule_update_ha_state = mock.Mock(return_value=None)
 EltakoEntity.send_message = mock.Mock(return_value=None)
 # EltakoBinarySensor.hass.bus.fire is mocked by class HassMock
 
@@ -144,3 +145,22 @@ class TestClimateAsync(unittest.IsolatedAsyncioTestCase):
         await cc.async_handle_event(EventDataMock({'switch_address': cooling_switch.id, 'data': cooling_switch[CONF_SWITCH_BUTTON]}))
         self.assertEquals(cc.hvac_mode, HVACMode.COOL)
 
+# class TestClimateInitialLoading(unittest.TestCase):
+
+    # def test_initial_loading(self):
+    #     cc = create_climate_entity()
+    #     cc._attr_native_value = None
+
+    #     cc.load_value_initially(LatestStateMock('25.5'))
+    #     self.assertEquals(cc._attr_native_value, 25.5)
+    #     self.assertEquals(cc.native_value, 25.5)
+    #     self.assertEquals(cc.state, '25.5')
+
+
+    # def test_initial_loading_None(self):
+        # cc = create_climate_entity()
+        # cc._attr_native_value = 25.5
+
+        # cc.load_value_initially(LatestStateMock('unknown'))
+        # self.assertIsNone(cc._attr_native_value)
+        # self.assertIsNone(cc.state)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -38,8 +38,8 @@ class TestClimate(unittest.TestCase):
 
     def test_climate_temp_actuator(self):
         cc = create_climate_entity()
-        self.assertEquals(cc.unique_id, 'eltako_gw12345_00-00-00-01')
-        self.assertEquals(cc.entity_id, 'climate.eltako_gw12345_00-00-00-01')
+        self.assertEquals(cc.unique_id, 'eltako_gw12345_00_00_00_01')
+        self.assertEquals(cc.entity_id, 'climate.eltako_gw12345_00_00_00_01')
         self.assertEquals(cc.dev_name, 'Room 1')
         self.assertEquals(cc.temperature_unit, '°C')
         self.assertEquals(cc.cooling_sender, None)
@@ -66,8 +66,8 @@ class TestClimate(unittest.TestCase):
             CONF_EEP: 'A5-10-06',
         })
         cc = create_climate_entity(thermostat)
-        self.assertEquals(cc.unique_id, 'eltako_gw12345_00-00-00-01')
-        self.assertEquals(cc.entity_id, 'climate.eltako_gw12345_00-00-00-01')
+        self.assertEquals(cc.unique_id, 'eltako_gw12345_00_00_00_01')
+        self.assertEquals(cc.entity_id, 'climate.eltako_gw12345_00_00_00_01')
         self.assertEquals(cc.dev_name, 'Room 1')
         self.assertEquals(cc.temperature_unit, '°C')
         self.assertEquals(cc.cooling_sender, None)
@@ -96,8 +96,8 @@ class TestClimate(unittest.TestCase):
             CONF_EEP: 'A5-10-06',
         })
         cc = create_climate_entity(cooling_switch=cooling_switch)
-        self.assertEquals(cc.unique_id, 'eltako_gw12345_00-00-00-01')
-        self.assertEquals(cc.entity_id, 'climate.eltako_gw12345_00-00-00-01')
+        self.assertEquals(cc.unique_id, 'eltako_gw12345_00_00_00_01')
+        self.assertEquals(cc.entity_id, 'climate.eltako_gw12345_00_00_00_01')
         self.assertEquals(cc.dev_name, 'Room 1')
         self.assertEquals(cc.temperature_unit, '°C')
         self.assertEquals(cc.cooling_sender, None)
@@ -126,8 +126,8 @@ class TestClimateAsync(unittest.IsolatedAsyncioTestCase):
             CONF_SWITCH_BUTTON: 0x50
         })
         cc = create_climate_entity(cooling_switch=cooling_switch)
-        self.assertEquals(cc.unique_id, 'eltako_gw12345_00-00-00-01')
-        self.assertEquals(cc.entity_id, 'climate.eltako_gw12345_00-00-00-01')
+        self.assertEquals(cc.unique_id, 'eltako_gw12345_00_00_00_01')
+        self.assertEquals(cc.entity_id, 'climate.eltako_gw12345_00_00_00_01')
         self.assertEquals(cc.dev_name, 'Room 1')
         self.assertEquals(cc.temperature_unit, '°C')
         self.assertEquals(cc.cooling_sender, None)

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -116,6 +116,31 @@ class TestClimate(unittest.TestCase):
         # self.assertEquals(cc._actuator_mode, A5_10_06.Heater_Mode.NORMAL);
         # self.assertEquals( round(cc.current_temperature), current_temperature)
         # self.assertEquals( round(cc.target_temperature), target_temp)
+
+
+    def test_initial_loading(self):
+        cc = create_climate_entity()
+
+        cc.load_value_initially(LatestStateMock('heat', 
+                                                attributes={'hvac_modes': ['heat', 'off'], 
+                                                            'min_temp': 17, 
+                                                            'max_temp': 25, 
+                                                            'current_temperature': 19.8, 
+                                                            'temperature': 22.5, 
+                                                            'friendly_name': 'Bad Room', 
+                                                            'supported_features': 385}))
+        self.assertEqual(cc.current_temperature, 19.8)
+        self.assertEqual(cc.target_temperature, 22.5)
+        self.assertEqual(cc.state, 'heat')
+
+
+    def test_initial_loading_None(self):
+        cc = create_climate_entity()
+
+        cc.load_value_initially(LatestStateMock(None))
+        self.assertEqual(cc.current_temperature, None)
+        self.assertEqual(cc.target_temperature, None)
+        self.assertEqual(cc.state, None)
     
 class TestClimateAsync(unittest.IsolatedAsyncioTestCase):
 
@@ -144,23 +169,3 @@ class TestClimateAsync(unittest.IsolatedAsyncioTestCase):
         # cc.value_changed(msg)
         await cc.async_handle_event(EventDataMock({'switch_address': cooling_switch.id, 'data': cooling_switch[CONF_SWITCH_BUTTON]}))
         self.assertEquals(cc.hvac_mode, HVACMode.COOL)
-
-# class TestClimateInitialLoading(unittest.TestCase):
-
-    # def test_initial_loading(self):
-    #     cc = create_climate_entity()
-    #     cc._attr_native_value = None
-
-    #     cc.load_value_initially(LatestStateMock('25.5'))
-    #     self.assertEquals(cc._attr_native_value, 25.5)
-    #     self.assertEquals(cc.native_value, 25.5)
-    #     self.assertEquals(cc.state, '25.5')
-
-
-    # def test_initial_loading_None(self):
-        # cc = create_climate_entity()
-        # cc._attr_native_value = 25.5
-
-        # cc.load_value_initially(LatestStateMock('unknown'))
-        # self.assertIsNone(cc._attr_native_value)
-        # self.assertIsNone(cc.state)

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -19,7 +19,9 @@ class TestCover(unittest.TestCase):
         self.last_sent_command = msg
 
     def create_cover(self) -> EltakoCover:
-        gateway = GatewayMock()
+        settings = DEFAULT_GENERAL_SETTINGS
+        settings[CONF_FAST_STATUS_CHANGE] = True
+        gateway = GatewayMock(settings)
         dev_id = AddressExpression.parse('00-00-00-01')
         dev_name = 'device name'
         device_class = "shutter"

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -36,15 +36,10 @@ class TestCover(unittest.TestCase):
         ec = EltakoCover(Platform.COVER, gateway, dev_id, dev_name, dev_eep, sender_id, sender_eep, device_class, time_closes, time_opens)
         ec.send_message = self.mock_send_message
 
-        ec._attr_is_closing = False
-        ec._attr_is_opening = False
-        self._attr_is_closed = False
-        self._attr_current_cover_position = 100
-
         self.assertEqual(ec._attr_is_closing, False)
         self.assertEqual(ec._attr_is_opening, False)
-        self.assertEqual(ec._attr_is_closed, False)
-        self.assertEqual(ec._attr_current_cover_position, 100)
+        self.assertEqual(ec._attr_is_closed, None)
+        self.assertEqual(ec._attr_current_cover_position, None)
 
         return ec
 
@@ -149,3 +144,57 @@ class TestCover(unittest.TestCase):
         ec.set_cover_position(position=100)
         self.assertEqual(self.last_sent_command, None)
         self.last_sent_command = None
+
+
+
+    def test_initial_loading_opening(self):
+        ec = self.create_cover()
+        ec._attr_is_closed = None
+        self.assertEqual(ec.is_closed, None)
+        self.assertEqual(ec.state, None)
+        
+        ec.load_value_initially(LatestStateMock('opening', {'current_position': 55}))
+        self.assertEqual(ec.is_closed, False)
+        self.assertEqual(ec.is_opening, True)
+        self.assertEqual(ec.is_closing, False)
+        self.assertEqual(ec.state, 'opening')
+        self.assertEqual(ec.current_cover_position, 55)
+
+    def test_initial_loading_closing(self):
+        ec = self.create_cover()
+        ec._attr_is_closed = None
+        self.assertEqual(ec.is_closed, None)
+        self.assertEqual(ec.state, None)
+        
+        ec.load_value_initially(LatestStateMock('closing', {'current_position': 33}))
+        self.assertEqual(ec.is_closed, False)
+        self.assertEqual(ec.is_opening, False)
+        self.assertEqual(ec.is_closing, True)
+        self.assertEqual(ec.state, 'closing')
+        self.assertEqual(ec.current_cover_position, 33)
+
+    def test_initial_loading_open(self):
+        ec = self.create_cover()
+        ec._attr_is_closed = None
+        self.assertEqual(ec.is_closed, None)
+        self.assertEqual(ec.state, None)
+        
+        ec.load_value_initially(LatestStateMock('open', {'current_position': 100}))
+        self.assertEqual(ec.is_closed, False)
+        self.assertEqual(ec.is_opening, False)
+        self.assertEqual(ec.is_closing, False)
+        self.assertEqual(ec.state, 'open')
+        self.assertEqual(ec.current_cover_position, 100)
+
+    def test_initial_loading_closed(self):
+        ec = self.create_cover()
+        ec._attr_is_closed = None
+        self.assertEqual(ec.is_closed, None)
+        self.assertEqual(ec.state, None)
+        
+        ec.load_value_initially(LatestStateMock('closed', {'current_position': 0}))
+        self.assertEqual(ec.is_closed, True)
+        self.assertEqual(ec.is_opening, False)
+        self.assertEqual(ec.is_closing, False)
+        self.assertEqual(ec.state, 'closed')
+        self.assertEqual(ec.current_cover_position, 0)

--- a/tests/test_device_entity.py
+++ b/tests/test_device_entity.py
@@ -34,15 +34,15 @@ class TestCover(unittest.TestCase):
         self.assertEquals(ee.unique_id, 'eltako_gw123_FE-34-21-01')
         self.assertEquals(ee.entity_id, 'binary_sensor.eltako_gw123_FE-34-21-01')
 
-    def test_load_initial_values(self):
-        pl = Platform.BINARY_SENSOR
-        gw = GatewayMock()
-        address = AddressExpression.parse('FE-34-21-01')
-        name = "Switch"
+    # def test_load_initial_values(self):
+    #     pl = Platform.BINARY_SENSOR
+    #     gw = GatewayMock()
+    #     address = AddressExpression.parse('FE-34-21-01')
+    #     name = "Switch"
 
-        ee = EltakoEntity(pl, gw, address, name, F6_02_01)
-        ee._attr_is_on = None
+    #     ee = EltakoEntity(pl, gw, address, name, F6_02_01)
+    #     ee._attr_is_on = None
 
-        ee.async_load_value_initially(LatestStateMock("true", {}))
+    #     ee.async_load_value_initially(LatestStateMock("true", {}))
 
-        # self.assertTrue(ee._attr_is_on)
+    #     # self.assertTrue(ee._attr_is_on)

--- a/tests/test_device_entity.py
+++ b/tests/test_device_entity.py
@@ -9,12 +9,13 @@ from custom_components.eltako.device import EltakoEntity
 from eltakobus import *
 
 from custom_components.eltako import config_helpers
+from homeassistant import core
 
 # mock update of Home Assistant
 Entity.schedule_update_ha_state = mock.Mock(return_value=None)
 # EltakoEntity.send_message = mock.Mock(return_value=None)
 
-class TestCover(unittest.TestCase):
+class TestEntityProperties(unittest.TestCase):
 
 
     def test_entity_properties(self):  
@@ -25,24 +26,15 @@ class TestCover(unittest.TestCase):
 
         ee = EltakoEntity(pl, gw, address, name, F6_02_01)
 
-        self.assertEquals(ee.dev_name, config_helpers.get_device_name(name, address, gw.general_settings))
+        self.assertEqual(ee.dev_name, config_helpers.get_device_name(name, address, gw.general_settings))
         
-        self.assertEquals(len(ee.listen_to_addresses),1)
-        self.assertEquals(ee.listen_to_addresses[0], b'\xfe4!\x01')
+        self.assertEqual(len(ee.listen_to_addresses),1)
+        self.assertEqual(ee.listen_to_addresses[0], b'\xfe4!\x01')
 
-        self.assertEquals(ee.dev_name, 'Switch')
-        self.assertEquals(ee.unique_id, 'eltako_gw123_FE-34-21-01')
-        self.assertEquals(ee.entity_id, 'binary_sensor.eltako_gw123_FE-34-21-01')
+        self.assertEqual(ee.dev_name, 'Switch')
+        self.assertEqual(ee.unique_id, 'eltako_gw123_fe_34_21_01')
+        self.assertEqual(ee.entity_id, 'binary_sensor.eltako_gw123_fe_34_21_01')
 
-    # def test_load_initial_values(self):
-    #     pl = Platform.BINARY_SENSOR
-    #     gw = GatewayMock()
-    #     address = AddressExpression.parse('FE-34-21-01')
-    #     name = "Switch"
-
-    #     ee = EltakoEntity(pl, gw, address, name, F6_02_01)
-    #     ee._attr_is_on = None
-
-    #     ee.async_load_value_initially(LatestStateMock("true", {}))
-
-    #     # self.assertTrue(ee._attr_is_on)
+        self.assertTrue( core.valid_domain(ee._attr_ha_platform) )
+        self.assertTrue( core.valid_entity_id(ee.entity_id) )
+        self.assertTrue( core.validate_state(ee.state))

--- a/tests/test_dimmable_light.py
+++ b/tests/test_dimmable_light.py
@@ -118,6 +118,7 @@ class TestDimmableLight(unittest.TestCase):
             self.last_sent_command.body,
             b"k\x07\x02'\x00\t\x00\x00\xb0\x01\x00")
 
+
     def test_initial_loading_on(self):
         sl = self.create_switchable_light()
         sl._attr_is_on = None
@@ -125,6 +126,27 @@ class TestDimmableLight(unittest.TestCase):
         sl.load_value_initially(LatestStateMock('on'))
         self.assertTrue(sl._attr_is_on)
         self.assertTrue(sl.is_on)
+        self.assertEqual(sl.brightness, None)
+        self.assertEqual(sl.state, 'on')
+
+    def test_initial_loading_on_with_brightness(self):
+        sl = self.create_switchable_light()
+        sl._attr_is_on = None
+
+        sl.load_value_initially(LatestStateMock('on', {'brightness': 100}))
+        self.assertTrue(sl._attr_is_on)
+        self.assertTrue(sl.is_on)
+        self.assertEqual(sl.brightness, 100)
+        self.assertEqual(sl.state, 'on')
+
+    def test_initial_loading_dimmed(self):
+        sl = self.create_switchable_light()
+        sl._attr_is_on = None
+
+        sl.load_value_initially(LatestStateMock('on', {'brightness': 100}))
+        self.assertTrue(sl._attr_is_on)
+        self.assertTrue(sl.is_on)
+        self.assertEqual(sl.brightness, 100)
         self.assertEquals(sl.state, 'on')
 
     def test_initial_loading_off(self):
@@ -134,6 +156,17 @@ class TestDimmableLight(unittest.TestCase):
         sl.load_value_initially(LatestStateMock('off'))
         self.assertFalse(sl._attr_is_on)
         self.assertFalse(sl.is_on)
+        self.assertEqual(sl.brightness, None)
+        self.assertEquals(sl.state, 'off')
+
+    def test_initial_loading_off_with_brightness(self):
+        sl = self.create_switchable_light()
+        sl._attr_is_on = None
+
+        sl.load_value_initially(LatestStateMock('off', {'brightness': 0}))
+        self.assertFalse(sl._attr_is_on)
+        self.assertFalse(sl.is_on)
+        self.assertEqual(sl.brightness, 0)
         self.assertEquals(sl.state, 'off')
 
     def test_initial_loading_None(self):
@@ -143,4 +176,5 @@ class TestDimmableLight(unittest.TestCase):
         sl.load_value_initially(LatestStateMock('bla'))
         self.assertIsNone(sl._attr_is_on)
         self.assertIsNone(sl.is_on)
+        self.assertIsNone(sl.brightness)
         self.assertIsNone(sl.state)

--- a/tests/test_dimmable_light.py
+++ b/tests/test_dimmable_light.py
@@ -1,0 +1,121 @@
+import unittest
+from custom_components.eltako.sensor import *
+from unittest import mock
+from mocks import *
+from homeassistant.helpers.entity import Entity
+from eltakobus import *
+from custom_components.eltako.light import EltakoDimmableLight
+
+
+# mock update of Home Assistant
+Entity.schedule_update_ha_state = mock.Mock(return_value=None)
+# EltakoEntity.send_message = mock.Mock(return_value=None)
+
+class TestSwitchableLight(unittest.TestCase):
+
+    def mock_send_message(self, msg: ESP2Message):
+        self.last_sent_command = msg
+
+    def create_switchable_light(self) -> EltakoDimmableLight:
+        gateway = GatewayMock()
+        dev_id = AddressExpression.parse('00-00-00-01')
+        dev_name = 'device name'
+        eep_string = 'M5-38-08'
+        
+        sender_id = AddressExpression.parse('00-00-B0-01')
+        sender_eep_string = 'A5-38-08'
+
+        dev_eep = EEP.find(eep_string)
+        sender_eep = EEP.find(sender_eep_string)
+
+        light = EltakoDimmableLight(Platform.LIGHT, gateway, dev_id, dev_name, dev_eep, sender_id, sender_eep)
+        return light
+
+    def test_switchable_light_value_changed(self):
+        light = self.create_switchable_light()
+        light._attr_is_on = None
+        self.assertEquals(light.is_on, None)
+        self.assertIsNone(light.state)
+
+        # status update message from relay
+        #8b 05 70 00 00 00 00 00 00 01 30
+        on_msg = RPSMessage(address=b'\x00\x00\x00\x01', status=b'\x30', data=b'\x70', outgoing=False)
+        # 8b 05 50 00 00 00 00 00 00 01 30
+        off_msg = RPSMessage(address=b'\x00\x00\x00\x01', status=b'\x30', data=b'\x50', outgoing=False)
+
+        light.value_changed(on_msg)
+        self.assertEquals(light.is_on, True)
+        self.assertEquals(light.state, 'on')
+
+        light.value_changed(on_msg)
+        self.assertEquals(light.is_on, True)
+        self.assertEquals(light.state, 'on')
+        
+        light.value_changed(off_msg)
+        self.assertEquals(light.is_on, False)
+        self.assertEquals(light.state, 'off')
+
+        light.value_changed(off_msg)
+        self.assertEquals(light.is_on, False)
+        self.assertEquals(light.state, 'off')
+
+        light.value_changed(on_msg)
+        self.assertEquals(light.is_on, True)
+        self.assertEquals(light.state, 'on')
+
+        light._attr_is_on = None
+        self.assertEquals(light.is_on, None)
+        self.assertIsNone(light.state)
+
+
+
+    def test_switchable_light_trun_on(self):
+        light = self.create_switchable_light()
+        light.send_message = self.mock_send_message
+        
+        # test if command is sent to eltako bus
+        light.turn_on()
+        self.assertEqual(
+            self.last_sent_command.body,
+            b'k\x07\x02d\x00\t\x00\x00\xb0\x01\x00')
+        
+    def test_switchable_light_trun_off(self):
+        light = self.create_switchable_light()
+        light.send_message = self.mock_send_message
+
+        # test if command is sent to eltako bus
+        light.turn_off()
+        self.assertEqual(
+            self.last_sent_command.body,
+            b'k\x07\x02\x00\x00\x08\x00\x00\xb0\x01\x00')
+
+    def test_dim_light(self):
+        light = self.create_switchable_light()
+        #TODO:
+
+    def test_initial_loading_on(self):
+        sl = self.create_switchable_light()
+        sl._attr_is_on = None
+
+        sl.load_value_initially(LatestStateMock('on'))
+        self.assertTrue(sl._attr_is_on)
+        self.assertTrue(sl.is_on)
+        self.assertEquals(sl.state, 'on')
+
+    def test_initial_loading_off(self):
+        sl = self.create_switchable_light()
+        sl._attr_is_on = None
+
+        sl.load_value_initially(LatestStateMock('off'))
+        self.assertFalse(sl._attr_is_on)
+        self.assertFalse(sl.is_on)
+        self.assertEquals(sl.state, 'off')
+
+    def test_initial_loading_None(self):
+        sl = self.create_switchable_light()
+        sl._attr_is_on = True
+
+        sl.load_value_initially(LatestStateMock('bla'))
+        self.assertIsNone(sl._attr_is_on)
+        self.assertIsNone(sl.is_on)
+        self.assertIsNone(sl.state)


### PR DESCRIPTION
* Trial to remove import warnings 
  Reported Issue: https://github.com/grimmpp/home-assistant-eltako/issues/61
* &#x1F41E; Removed entity_id bug from GatewayConnectionState &#x1F41E; => Requires removing and adding gateway again ❗
* Added state cache of device entities. When restarting HA entities like temperature sensors will show previouse state/value after restart. 
  Reported Feature: https://github.com/grimmpp/home-assistant-eltako/issues/63