### PR TITLE
added feature to tilt the cover

### DIFF
--- a/custom_components/eltako/const.py
+++ b/custom_components/eltako/const.py
@@ -55,6 +55,7 @@ CONF_ID_REGEX: Final = "^([0-9a-fA-F]{2})-([0-9a-fA-F]{2})-([0-9a-fA-F]{2})-([0-
 CONF_METER_TARIFFS: Final = "meter_tariffs"
 CONF_TIME_CLOSES: Final = "time_closes"
 CONF_TIME_OPENS: Final = "time_opens"
+CONF_TIME_TILTS: Final = "time_tilts"
 CONF_INVERT_SIGNAL: Final = "invert_signal"
 CONF_VOC_TYPE_INDEXES: Final = "voc_type_indexes"
 

--- a/custom_components/eltako/schema.py
+++ b/custom_components/eltako/schema.py
@@ -206,6 +206,7 @@ class CoverSchema(EltakoPlatformSchema):
                 vol.Optional(CONF_DEVICE_CLASS): COVER_DEVICE_CLASSES_SCHEMA,
                 vol.Optional(CONF_TIME_CLOSES): vol.All(vol.Coerce(int), vol.Range(min=1, max=255)),
                 vol.Optional(CONF_TIME_OPENS): vol.All(vol.Coerce(int), vol.Range(min=1, max=255)),
+                vol.Optional(CONF_TIME_TILTS): vol.All(vol.Coerce(int), vol.Range(min=1, max=255)),
             }
         ),
     )

--- a/tests/test_cover_G5_3F_7F.py
+++ b/tests/test_cover_G5_3F_7F.py
@@ -35,13 +35,42 @@ class TestCover(unittest.TestCase):
         dev_eep = EEP.find(eep_string)
         sender_eep = EEP.find(sender_eep_string)
 
-        ec = EltakoCover(Platform.COVER, gateway, dev_id, dev_name, dev_eep, sender_id, sender_eep, device_class, time_closes, time_opens)
+        ec = EltakoCover(Platform.COVER, gateway, dev_id, dev_name, dev_eep, sender_id, sender_eep, device_class, time_closes, time_opens, None)
         ec.send_message = self.mock_send_message
 
         self.assertEqual(ec._attr_is_closing, False)
         self.assertEqual(ec._attr_is_opening, False)
         self.assertEqual(ec._attr_is_closed, None)
         self.assertEqual(ec._attr_current_cover_position, None)
+
+        return ec
+
+    def create_blind(self) -> EltakoCover:
+        settings = DEFAULT_GENERAL_SETTINGS
+        settings[CONF_FAST_STATUS_CHANGE] = True
+        gateway = GatewayMock(settings)
+        dev_id = AddressExpression.parse('00-00-00-01')
+        dev_name = 'device name'
+        device_class = "blind"
+        time_closes = 10
+        time_opens = 10
+        time_tilts: 15
+        eep_string = "G5-3F-7F"
+
+        sender_id = AddressExpression.parse("00-00-B1-07")
+        sender_eep_string = "H5-3F-7F"
+
+        dev_eep = EEP.find(eep_string)
+        sender_eep = EEP.find(sender_eep_string)
+
+        ec = EltakoCover(Platform.COVER, gateway, dev_id, dev_name, dev_eep, sender_id, sender_eep, device_class, time_closes, time_opens, time_tilts)
+        ec.send_message = self.mock_send_message
+
+        self.assertEqual(ec._attr_is_closing, False)
+        self.assertEqual(ec._attr_is_opening, False)
+        self.assertEqual(ec._attr_is_closed, None)
+        self.assertEqual(ec._attr_current_cover_position, None)
+        self.assertEqual(ec._attr_current_cover_tilt_position, None)
 
         return ec
 
@@ -69,6 +98,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(ec._attr_is_opening, False)
         self.assertEqual(ec._attr_is_closed, True)
         self.assertEqual(ec._attr_current_cover_position, 0)
+        self.assertEqual(ec._attr_current_cover_tilt_position, None)
 
         # device send acknowledgement for opened
         msg = RPSMessage(address=b'\x00\x00\x00\x01', status=b'\x30', data=b'\x70', outgoing=False)
@@ -77,7 +107,45 @@ class TestCover(unittest.TestCase):
         self.assertEqual(ec._attr_is_opening, False)
         self.assertEqual(ec._attr_is_closed, False)
         self.assertEqual(ec._attr_current_cover_position, 100)
+        self.assertEqual(ec._attr_current_cover_tilt_position, None)
 
+
+
+        ec = self.create_blind()
+
+        # status update message form device
+        # device send acknowledgement for opening
+        msg = RPSMessage(address=b'\x00\x00\x00\x01', status=b'\x30', data=b'\x01', outgoing=False)
+        ec.value_changed(msg)
+        self.assertEqual(ec._attr_is_closing, False)
+        self.assertEqual(ec._attr_is_opening, True)
+
+        # device send acknowledgement for closing
+        msg = RPSMessage(address=b'\x00\x00\x00\x01', status=b'\x30', data=b'\x02', outgoing=False)
+        ec.value_changed(msg)
+        self.assertEqual(ec._attr_is_closing, True)
+        self.assertEqual(ec._attr_is_opening, False)
+
+        # device send acknowledgement for closed
+        msg = RPSMessage(address=b'\x00\x00\x00\x01', status=b'\x30', data=b'\x50', outgoing=False)
+        ec.value_changed(msg)
+        self.assertEqual(ec._attr_is_closing, False)
+        self.assertEqual(ec._attr_is_opening, False)
+        self.assertEqual(ec._attr_is_closed, True)
+        self.assertEqual(ec._attr_current_cover_position, 0)
+        self.assertEqual(ec._attr_current_cover_tilt_position, 0)
+
+
+        # device send acknowledgement for opened
+        msg = RPSMessage(address=b'\x00\x00\x00\x01', status=b'\x30', data=b'\x70', outgoing=False)
+        ec.value_changed(msg)
+        self.assertEqual(ec._attr_is_closing, False)
+        self.assertEqual(ec._attr_is_opening, False)
+        self.assertEqual(ec._attr_is_closed, False)
+        self.assertEqual(ec._attr_current_cover_position, 100)
+        self.assertEqual(ec._attr_current_cover_tilt_position, 100)
+
+        
 
     def test_cover_intermediate_cover_positions(self):
         ec = self.create_cover()
@@ -176,6 +244,51 @@ class TestCover(unittest.TestCase):
         self.assertEqual(self.last_sent_command, None)
         self.last_sent_command = None
 
+#############################################################################################
+    def test_set_cover_tilt_position(self):
+        ec = self.create_blind()
+
+        ec._attr_current_cover_position = 100
+        ec.set_cover_position(position=50)
+        self.assertEqual(
+            self.last_sent_command.body,
+            b'k\x07\x00\x05\x02\x08\x00\x00\xb1\x06\x00')
+        self.assertEqual(ec._attr_is_closing, True)
+        self.assertEqual(ec._attr_is_opening, False)
+        self.last_sent_command = None
+
+        ec._attr_current_cover_position = 0
+        ec.set_cover_position(position=50)
+        self.assertEqual(
+            self.last_sent_command.body,
+            b'k\x07\x00\x05\x01\x08\x00\x00\xb1\x06\x00')
+        self.assertEqual(ec._attr_is_closing, False)
+        self.assertEqual(ec._attr_is_opening, True)
+        self.last_sent_command = None
+        
+        ec._attr_current_cover_position = 100
+        ec.set_cover_position(position=0)
+        self.assertEqual(
+            self.last_sent_command.body,
+            b'k\x07\x00\x0b\x02\x08\x00\x00\xb1\x06\x00')
+        self.assertEqual(ec._attr_is_closing, True)
+        self.assertEqual(ec._attr_is_opening, False)
+        self.last_sent_command = None
+
+        ec._attr_current_cover_position = 0
+        ec.set_cover_position(position=100)
+        self.assertEqual(
+            self.last_sent_command.body,
+            b'k\x07\x00\x0b\x01\x08\x00\x00\xb1\x06\x00')
+        self.assertEqual(ec._attr_is_closing, False)
+        self.assertEqual(ec._attr_is_opening, True)
+        self.last_sent_command = None
+
+        ec._attr_current_cover_position = 100
+        ec.set_cover_position(position=100)
+        self.assertEqual(self.last_sent_command, None)
+        self.last_sent_command = None
+#############################################################################################
 
 
     def test_initial_loading_opening(self):
@@ -184,12 +297,13 @@ class TestCover(unittest.TestCase):
         self.assertEqual(ec.is_closed, None)
         self.assertEqual(ec.state, None)
         
-        ec.load_value_initially(LatestStateMock('opening', {'current_position': 55}))
+        ec.load_value_initially(LatestStateMock('opening', {'current_position': 55, 'current_tilt_position': 20}))
         self.assertEqual(ec.is_closed, False)
         self.assertEqual(ec.is_opening, True)
         self.assertEqual(ec.is_closing, False)
         self.assertEqual(ec.state, 'opening')
         self.assertEqual(ec.current_cover_position, 55)
+        self.assertEqual(ec.current_tilt_position, 20)
 
     def test_initial_loading_closing(self):
         ec = self.create_cover()
@@ -197,12 +311,13 @@ class TestCover(unittest.TestCase):
         self.assertEqual(ec.is_closed, None)
         self.assertEqual(ec.state, None)
         
-        ec.load_value_initially(LatestStateMock('closing', {'current_position': 33}))
+        ec.load_value_initially(LatestStateMock('closing', {'current_position': 33, 'current_tilt_position': 10}))
         self.assertEqual(ec.is_closed, False)
         self.assertEqual(ec.is_opening, False)
         self.assertEqual(ec.is_closing, True)
         self.assertEqual(ec.state, 'closing')
         self.assertEqual(ec.current_cover_position, 33)
+        self.assertEqual(ec.current_tilt_position, 10)
 
     def test_initial_loading_open(self):
         ec = self.create_cover()
@@ -210,12 +325,13 @@ class TestCover(unittest.TestCase):
         self.assertEqual(ec.is_closed, None)
         self.assertEqual(ec.state, None)
         
-        ec.load_value_initially(LatestStateMock('open', {'current_position': 100}))
+        ec.load_value_initially(LatestStateMock('open', {'current_position': 100, 'current_tilt_position': 100}))
         self.assertEqual(ec.is_closed, False)
         self.assertEqual(ec.is_opening, False)
         self.assertEqual(ec.is_closing, False)
         self.assertEqual(ec.state, 'open')
         self.assertEqual(ec.current_cover_position, 100)
+        self.assertEqual(ec.current_tilt_position, 100)
 
     def test_initial_loading_closed(self):
         ec = self.create_cover()
@@ -223,12 +339,13 @@ class TestCover(unittest.TestCase):
         self.assertEqual(ec.is_closed, None)
         self.assertEqual(ec.state, None)
         
-        ec.load_value_initially(LatestStateMock('closed', {'current_position': 0}))
+        ec.load_value_initially(LatestStateMock('closed', {'current_position': 0, 'current_tilt_position': 0}))
         self.assertEqual(ec.is_closed, True)
         self.assertEqual(ec.is_opening, False)
         self.assertEqual(ec.is_closing, False)
         self.assertEqual(ec.state, 'closed')
         self.assertEqual(ec.current_cover_position, 0)
+        self.assertEqual(ec.current_tilt_position, 0)
 
 
 


### PR DESCRIPTION
add feature to set the tilt position for raffstore
small changes don't work properly
had to use time.sleep and a normal open/close + stop message.
while adjusting the tilt you should not request a new tilt position
I used a blind as device_class to get an other default symbol in HA