### PR TITLE
Change received-messages sensor to a valid `unit_of_measurement`

### DIFF
--- a/custom_components/eltako/sensor.py
+++ b/custom_components/eltako/sensor.py
@@ -908,7 +908,7 @@ class GatewayReceivedMessagesInActiveSession(EltakoSensor):
                             state_class=SensorStateClass.TOTAL_INCREASING,
                             # device_class=SensorDeviceClass.VOLUME,
                             # native_unit_of_measurement="Messages", # => raises error message
-                            unit_of_measurement="Messages",
+                            unit_of_measurement="count",
                             suggested_unit_of_measurement="Messages",
                             icon="mdi:chart-line",
                         )


### PR DESCRIPTION
The sensor for received messages of a gateway has a `state_class=SensorStateClass.TOTAL_INCREASING`. For a sensor with this `state_class`, a custom `unit_of_measurement` is not allowed, which leads to this error:

```
2025-09-11 12:02:24.916 ERROR (MainThread) [homeassistant.components.sensor] Error adding entity sensor.eltako_gw1_xx_xx_xx_xx_received_messages_per_session for domain sensor with platform eltako
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 676, in _async_add_entities
    await self._async_add_entity(
        entity, False, entity_registry, config_subentry_id
    )
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 915, in _async_add_entity
    unit_of_measurement=entity.unit_of_measurement,
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 524, in unit_of_measurement
    if self._is_valid_suggested_unit(suggested_unit_of_measurement):
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 376, in _is_valid_suggested_unit
    raise ValueError(
    ...<2 lines>...
    )
ValueError: Entity <class 'custom_components.eltako.sensor.GatewayReceivedMessagesInActiveSession'> suggest an incorrect unit of measurement: Messages.
```

This PR changes the unit to a simple `count`, which should fix the above error, while still displaying the unit as "Messages" via the `suggested_unit_of_measurement`.