### PR TITLE
fix: Stabilize serial handling and reduce event-loop pressure

### DIFF
--- a/custom_components/eltako/binary_sensor.py
+++ b/custom_components/eltako/binary_sensor.py
@@ -18,7 +18,6 @@ from .gateway import EnOceanGateway
 from .schema import CONF_EEP_SUPPORTED_BINARY_SENSOR
 from . import config_helpers, get_gateway_from_hass, get_device_config_for_gateway
 
-import json
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -156,7 +155,6 @@ class EltakoBinarySensor(AbstractBinarySensor):
         
         try:
             decoded = self.dev_eep.decode_message(msg)
-            LOGGER.debug("decoded : %s", json.dumps(decoded.__dict__))
             # LOGGER.debug("msg : %s, data: %s", type(msg), msg.data)
         except Exception as e:
             LOGGER.warning("[%s %s] Could not decode message for eep %s does not fit to message type %s (org %s)", 
@@ -210,7 +208,7 @@ class EltakoBinarySensor(AbstractBinarySensor):
                     "rocker_second_action": decoded.rocker_second_action,
                 }
             
-            LOGGER.debug("[%s %s] Send event: %s, pressed_buttons: '%s'", Platform.BINARY_SENSOR, str(self.dev_id), event_id, json.dumps(pressed_buttons))
+            LOGGER.debug("[%s %s] Send event: %s, pressed_buttons: %s", Platform.BINARY_SENSOR, str(self.dev_id), event_id, pressed_buttons)
             self.hass.bus.fire(event_id, event_data)
 
             # fire second event for a specific buttons pushed on the swtich
@@ -225,7 +223,7 @@ class EltakoBinarySensor(AbstractBinarySensor):
                     "rocker_first_action": decoded.rocker_first_action,
                     "rocker_second_action": decoded.rocker_second_action,
                 }
-            LOGGER.debug("[%s %s] Send event: %s, pressed_buttons: '%s'", Platform.BINARY_SENSOR, str(self.dev_id), event_id, json.dumps(pressed_buttons))
+            LOGGER.debug("[%s %s] Send event: %s, pressed_buttons: %s", Platform.BINARY_SENSOR, str(self.dev_id), event_id, pressed_buttons)
             self.hass.bus.fire(event_id, event_data)
 
             # Show status change in HA. It will only for the moment when the button is pushed down.

--- a/custom_components/eltako/button.py
+++ b/custom_components/eltako/button.py
@@ -133,4 +133,4 @@ class GatewayReconnectButton(AbstractButton):
 
     async def async_press(self) -> None:
         """Reconnect serial bus"""
-        self.gateway.reconnect()
+        await self.gateway.async_reconnect()

--- a/custom_components/eltako/climate.py
+++ b/custom_components/eltako/climate.py
@@ -56,19 +56,12 @@ async def async_setup_entry(
 
                 if dev_conf.eep in [A5_10_06]:
                     ###### This way it is decouple from the order how devices will be loaded.
-                    climate_entity = ClimateController(platform, gateway, dev_conf.id, dev_conf.name, dev_conf.eep, 
-                                                       sender.id, sender.eep, 
-                                                       dev_conf.get(CONF_TEMPERATURE_UNIT), 
-                                                       dev_conf.get(CONF_MIN_TARGET_TEMPERATURE), dev_conf.get(CONF_MAX_TARGET_TEMPERATURE), 
+                    climate_entity = ClimateController(platform, gateway, dev_conf.id, dev_conf.name, dev_conf.eep,
+                                                       sender.id, sender.eep,
+                                                       dev_conf.get(CONF_TEMPERATURE_UNIT),
+                                                       dev_conf.get(CONF_MIN_TARGET_TEMPERATURE), dev_conf.get(CONF_MAX_TARGET_TEMPERATURE),
                                                        thermostat, cooling_switch, cooling_sender)
                     entities.append(climate_entity)
-
-                    # subscribe for cooling switch events
-                    if cooling_switch is not None:
-                        event_id = config_helpers.get_bus_event_type(gateway.base_id, EVENT_BUTTON_PRESSED, cooling_switch.id, 
-                                                                     config_helpers.convert_button_pos_from_hex_to_str(cooling_switch.get(CONF_SWITCH_BUTTON)))
-                        LOGGER.debug(f"Subscribe for listening to cooling switch events: {event_id}")
-                        hass.bus.async_listen(event_id, climate_entity.async_handle_event)
 
             except Exception as e:
                 LOGGER.warning("[%s] Could not load configuration", platform)
@@ -121,7 +114,7 @@ class ClimateController(EltakoEntity, ClimateEntity, RestoreEntity):
 
         self.thermostat = thermostat
         if self.thermostat:
-            self.listen_to_addresses.append(self.thermostat.id)
+            self.listen_to_addresses.add(self.thermostat.id)
 
         self.cooling_switch = cooling_switch
         self.cooling_switch_last_signal_timestamp = 0
@@ -139,9 +132,34 @@ class ClimateController(EltakoEntity, ClimateEntity, RestoreEntity):
         self._attr_max_temp = max_temp
         self._attr_min_temp = min_temp
 
-        self._loop = asyncio.get_event_loop()
-        self._update_task = asyncio.ensure_future(self._wrapped_update(), loop=self._loop)
+        self._update_task = None
 
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to cooling switch events and start update task when added to hass."""
+        await super().async_added_to_hass()
+
+        # Start periodic update task
+        self._update_task = asyncio.ensure_future(self._wrapped_update())
+
+        if self.cooling_switch:
+            event_id = config_helpers.get_bus_event_type(
+                self.gateway.base_id, EVENT_BUTTON_PRESSED, self.cooling_switch.id,
+                config_helpers.convert_button_pos_from_hex_to_str(self.cooling_switch.get(CONF_SWITCH_BUTTON))
+            )
+            LOGGER.debug(f"[climate {self.dev_id}] Subscribe for cooling switch events: {event_id}")
+            self.async_on_remove(
+                self.hass.bus.async_listen(event_id, self.async_handle_event)
+            )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel periodic update task on removal."""
+        if self._update_task:
+            self._update_task.cancel()
+            try:
+                await self._update_task
+            except asyncio.CancelledError:
+                pass
+        await super().async_will_remove_from_hass()
 
     def load_value_initially(self, latest_state:State):
         # LOGGER.debug(f"[climate {self.dev_id}] eneity unique_id: {self.unique_id}")

--- a/custom_components/eltako/cover.py
+++ b/custom_components/eltako/cover.py
@@ -19,6 +19,7 @@ from .config_helpers import DeviceConf
 from .gateway import EnOceanGateway
 from .const import CONF_SENDER, CONF_TIME_CLOSES, CONF_TIME_OPENS, CONF_TIME_TILTS, DOMAIN, MANUFACTURER, LOGGER
 from . import get_gateway_from_hass, get_device_config_for_gateway
+import asyncio
 import time
 
 async def async_setup_entry(
@@ -322,10 +323,10 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
             self.schedule_update_ha_state()
 
 
-    def set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         address, _ = self._sender_id
         tilt_position = kwargs[ATTR_TILT_POSITION]
-        
+
         if tilt_position == self._attr_current_cover_tilt_position:
             return
         elif tilt_position > self._attr_current_cover_tilt_position:
@@ -340,10 +341,10 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
                 command = 0x01
             elif direction == "down":
                 command = 0x02
-            
+
             msg = H5_3F_7F(0, command, 1).encode_message(address)
             self.send_message(msg)
-            time.sleep(sleeptime)
+            await asyncio.sleep(sleeptime)
             
             msg = H5_3F_7F(0, 0x00, 1).encode_message(address)
             self.send_message(msg)

--- a/custom_components/eltako/device.py
+++ b/custom_components/eltako/device.py
@@ -20,12 +20,14 @@ from . import config_helpers
 
 class EltakoEntity(Entity):
     """Parent class for all entities associated with the Eltako component."""
-    
-    
+
+    # Message types we handle - class constant to avoid per-message allocation
+    _HANDLED_MSG_TYPES = (EltakoWrappedRPS, EltakoWrapped1BS, EltakoWrapped4BS, RPSMessage, Regular1BSMessage, Regular4BSMessage)
+
     def __init__(self, platform: str, gateway: EnOceanGateway, dev_id: AddressExpression, dev_name: str="Device", dev_eep: EEP=None, description_key:str=None):
         """Initialize the device."""
         self._attr_has_entity_name = True
-        self._attr_should_poll = True
+        self._attr_should_poll = False
 
         self._attr_ha_platform = platform
         self._attr_gateway = gateway
@@ -34,8 +36,7 @@ class EltakoEntity(Entity):
         self._attr_dev_id = dev_id
         self._attr_dev_name = config_helpers.get_device_name(dev_name, dev_id, self.general_settings)
         self._attr_dev_eep = dev_eep
-        self.listen_to_addresses = []
-        self.listen_to_addresses.append(self.dev_id[0])
+        self.listen_to_addresses = {self.dev_id[0]}  # Set for O(1) address lookup
         self.description_key = description_key
         self._attr_unique_id = EltakoEntity._get_identifier(self.gateway, self.dev_id, self._get_description_key())
         self.entity_id = f"{self._attr_ha_platform}.{self._attr_unique_id}"
@@ -78,14 +79,18 @@ class EltakoEntity(Entity):
     async def async_added_to_hass(self) -> None:
         """Call when entity about to be added to hass."""
         await super().async_added_to_hass()
-        
-        # Register callbacks.
-        event_id = config_helpers.get_bus_event_type(self.gateway.base_id, SIGNAL_RECEIVE_MESSAGE)
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass, event_id, self._message_received_callback
+
+        # Register callbacks for each address this entity listens to.
+        for address in self.listen_to_addresses:
+            normalized_address = self._normalize_listen_address(address)
+            event_id = config_helpers.get_bus_event_type(
+                self.gateway.base_id, SIGNAL_RECEIVE_MESSAGE, normalized_address
             )
-        )
+            self.async_on_remove(
+                async_dispatcher_connect(
+                    self.hass, event_id, self._message_received_callback
+                )
+            )
 
         # load initial value
         if isinstance(self, RestoreEntity):
@@ -114,13 +119,12 @@ class EltakoEntity(Entity):
 
 
     def validate_sender_id(self, sender_id=None) -> bool:
-        
         if sender_id is None:
             if hasattr(self, "sender_id"):
                 sender_id = self.sender_id
 
         if sender_id is not None:
-            return self.gateway.validate_sender_id(self.sender_id, self.dev_name)
+            return self.gateway.validate_sender_id(sender_id, self.dev_name)
         return True
 
     @property
@@ -160,12 +164,8 @@ class EltakoEntity(Entity):
 
     def _message_received_callback(self, msg: ESP2Message) -> None:
         """Handle incoming messages."""
-        
-        msg_types = [EltakoWrappedRPS, EltakoWrapped1BS, EltakoWrapped4BS, RPSMessage, Regular1BSMessage, Regular4BSMessage]
-
-        if type(msg) in msg_types:
-            if msg.address in self.listen_to_addresses:
-                self.value_changed(msg)
+        if isinstance(msg, self._HANDLED_MSG_TYPES):
+            self.value_changed(msg)
 
 
     def value_changed(self, msg: ESP2Message):
@@ -175,6 +175,12 @@ class EltakoEntity(Entity):
         """Put message on RS485 bus. First the message is put onto HA event bus so that other automations can react on messages."""
         event_id = config_helpers.get_bus_event_type(self.gateway.base_id, SIGNAL_SEND_MESSAGE)
         dispatcher_send(self.hass, event_id, msg)
+
+    def _normalize_listen_address(self, address):
+        """Normalize listen addresses to AddressExpression-compatible form."""
+        if isinstance(address, (bytes, bytearray)):
+            return AddressExpression((bytes(address), None))
+        return address
         
 
 def validate_actuators_dev_and_sender_id(entities:list[EltakoEntity]):

--- a/custom_components/eltako/eltako_integration_init.py
+++ b/custom_components/eltako/eltako_integration_init.py
@@ -160,7 +160,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     gateway = get_gateway_from_hass(hass, config_entry)
 
     LOGGER.info("Unload %s and all its supported devices!", gateway.dev_name)
-    gateway.unload()
+    await gateway.async_unload()
     del hass.data[DATA_ELTAKO][gateway.dev_name]
 
     return True

--- a/custom_components/eltako/gateway.py
+++ b/custom_components/eltako/gateway.py
@@ -6,7 +6,7 @@ import pytz
 from datetime import datetime, UTC
 
 import serial
-import asyncio
+import time
 
 from eltakobus.serial import RS485SerialInterfaceV2
 from eltakobus.message import ESP2Message, EltakoPoll
@@ -16,7 +16,7 @@ from eltakobus.eep import EEP
 
 from homeassistant.core import HomeAssistant
 from homeassistant.const import CONF_MAC
-from homeassistant.helpers.dispatcher import async_dispatcher_connect, dispatcher_send
+from homeassistant.helpers.dispatcher import async_dispatcher_connect, async_dispatcher_send
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.config_entries import ConfigEntry
@@ -52,7 +52,6 @@ class EnOceanGateway:
 
         """Initialize the Eltako gateway."""
 
-        self._loop = asyncio.get_event_loop()
         self._bus_task = None
         self.baud_rate = baud_rate
         self._auto_reconnect = auto_reconnect
@@ -71,6 +70,8 @@ class EnOceanGateway:
         self._last_message_received_handler = None
         self._connection_state_handler = None
         self._received_message_count_handler = None
+        self._last_stats_update = 0.0  # monotonic timestamp for throttling
+        self._stats_update_interval = 1.0  # seconds between stats updates to HA
 
         self._attr_model = GATEWAY_DEFAULT_NAME + " - " + self.dev_type.upper()
 
@@ -91,6 +92,14 @@ class EnOceanGateway:
 
 
     def _fire_connection_state_changed_event(self, status):
+        """Called from serial thread - schedule on event loop."""
+        if self._connection_state_handler:
+            self.hass.loop.call_soon_threadsafe(
+                self._schedule_connection_state_update, status
+            )
+
+    def _schedule_connection_state_update(self, status):
+        """Run on event loop to safely create task."""
         if self._connection_state_handler:
             self.hass.create_task(
                 self._connection_state_handler(status)
@@ -113,7 +122,6 @@ class EnOceanGateway:
 
 
     def _fire_received_message_count_event(self):
-        self._received_message_count += 1
         if self._received_message_count_handler:
             self.hass.create_task(
                 self._received_message_count_handler( self._received_message_count ),
@@ -121,8 +129,15 @@ class EnOceanGateway:
 
     def process_messages(self, data=None):
         """Received message from bus in HA loop. (Actions needs to run outside bus thread!)"""
-        self._fire_received_message_count_event()
-        self._fire_last_message_received_event()
+        # Always increment counter for accuracy
+        self._received_message_count += 1
+
+        # Throttle HA state updates to reduce event loop pressure under heavy traffic
+        now = time.monotonic()
+        if now - self._last_stats_update >= self._stats_update_interval:
+            self._last_stats_update = now
+            self._fire_received_message_count_event()
+            self._fire_last_message_received_event()
 
     
     def _init_bus(self):
@@ -197,14 +212,19 @@ class EnOceanGateway:
 
 
     def dev_id_validation_by_transmitter(self, dev_id: AddressExpression, device_name: str = "") -> bool:
-        result = 0xFF == dev_id[0][0]
+        # Wireless senders have IDs starting with FE or FF
+        result = dev_id[0][0] in (0xFE, 0xFF)
         if not result:
             LOGGER.warn(f"{device_name} ({dev_id}): Maybe have wrong device id configured!")
         return result
     
 
     def dev_id_validation_by_bus_gateway(self, dev_id: AddressExpression, device_name: str = "") -> bool:
-        result = config_helpers.compare_enocean_ids(b'\x00\x00\x00\x00', dev_id[0], len=2)
+        # Bus devices have IDs in 00-00-XX-XX range
+        is_bus_device = config_helpers.compare_enocean_ids(b'\x00\x00\x00\x00', dev_id[0], len=2)
+        # Wireless senders (PTM buttons, etc.) have IDs starting with FE or FF
+        is_wireless_sender = dev_id[0][0] in (0xFE, 0xFF)
+        result = is_bus_device or is_wireless_sender
         if not result:
             LOGGER.warn(f"{device_name} ({dev_id}): Maybe have wrong device id configured!")
         return result
@@ -213,8 +233,10 @@ class EnOceanGateway:
     ### send and receive funtions for RS485 bus (serial bus)
     ### all events are looped through the HA event bus so that other automations can work with those events. History about events can aslo be created.
 
-    def reconnect(self):
+    async def async_reconnect(self):
         self._bus.stop()
+        # Wait for old thread to terminate before creating new one (prevents thread leaks)
+        await self.hass.async_add_executor_job(self._bus.join)
         self._init_bus()
         self._bus.start()
 
@@ -274,7 +296,7 @@ class EnOceanGateway:
         try:
             # create message
             msg = eep.encode_message(sender_id[0])
-            LOGGER.debug(f"[Service Send Message: {event.service}] Generated message: {msg} Serialized: {msg.serialize().hex()}")
+            LOGGER.debug("[Service Send Message: %s] Generated message: %s", event.service, msg)
             # send message
             self.send_message(msg)
         except Exception as e:
@@ -287,14 +309,15 @@ class EnOceanGateway:
     def send_message(self, msg: ESP2Message):
         """Put message on RS485 bus. First the message is put onto HA event bus so that other automations can react on messages."""
         event_id = config_helpers.get_bus_event_type(self.base_id, SIGNAL_SEND_MESSAGE)
-        dispatcher_send(self.hass, event_id, msg)
+        async_dispatcher_send(self.hass, event_id, msg)
 
 
-    def unload(self):
+    async def async_unload(self):
         """Disconnect callbacks established at init time."""
         if self.dispatcher_disconnect_handle:
             self._bus.stop()
-            self._bus.join()
+            # Run blocking join() in executor to avoid blocking the event loop
+            await self.hass.async_add_executor_job(self._bus.join)
             LOGGER.debug("[Gateway] [Id: %d] Was stopped.", self.dev_id)
             self.dispatcher_disconnect_handle()
             self.dispatcher_disconnect_handle = None
@@ -304,7 +327,7 @@ class EnOceanGateway:
         """Callback method call from HA when receiving events from serial bus."""
         if self._bus.is_active():
             if isinstance(msg, ESP2Message):
-                LOGGER.debug("[Gateway] [Id: %d] Send message: %s - Serialized: %s", self.dev_id, msg, msg.serialize().hex())
+                LOGGER.debug("[Gateway] [Id: %d] Send message: %s", self.dev_id, msg)
 
                 # put message on serial bus
                 self.hass.create_task(
@@ -317,17 +340,26 @@ class EnOceanGateway:
     def _callback_receive_message_from_serial_bus(self, message):
         """Handle Eltako device's callback.
 
-        This is the callback function called by python-enocan whenever there
-        is an incoming message.
+        This is the callback function called by the serial bus thread whenever
+        there is an incoming message. Schedule all processing on the HA event
+        loop to ensure thread safety.
         """
-
         if type(message) not in [EltakoPoll]:
-            LOGGER.debug("[Gateway] [Id: %d] Received message: %s", self.dev_id, message)
-            self.process_messages()
+            self.hass.loop.call_soon_threadsafe(
+                self._process_message_on_event_loop, message
+            )
 
-            if isinstance(message, ESP2Message):
-                event_id = config_helpers.get_bus_event_type(self.base_id, SIGNAL_RECEIVE_MESSAGE)
-                dispatcher_send(self.hass, event_id, message)
+    def _process_message_on_event_loop(self, message):
+        """Process message on HA event loop (called via call_soon_threadsafe)."""
+        LOGGER.debug("[Gateway] [Id: %d] Received message: %s", self.dev_id, message)
+        self.process_messages()
+
+        if isinstance(message, ESP2Message):
+            # Emit address-scoped event so only interested entities receive it
+            event_id = config_helpers.get_bus_event_type(
+                self.base_id, SIGNAL_RECEIVE_MESSAGE, (message.address, None)
+            )
+            async_dispatcher_send(self.hass, event_id, message)
             
     @property
     def unique_id(self) -> str:

--- a/custom_components/eltako/sensor.py
+++ b/custom_components/eltako/sensor.py
@@ -906,10 +906,6 @@ class GatewayReceivedMessagesInActiveSession(EltakoSensor):
                             key="Received Messages per Session",
                             name="Received Messages per Session",
                             state_class=SensorStateClass.TOTAL_INCREASING,
-                            # device_class=SensorDeviceClass.VOLUME,
-                            # native_unit_of_measurement="Messages", # => raises error message
-                            unit_of_measurement="Messages",
-                            suggested_unit_of_measurement="Messages",
                             icon="mdi:chart-line",
                         )
         )
@@ -993,8 +989,8 @@ class EventListenerInfoField(EltakoSensor):
 
     def __init__(self, platform: str, gateway: EnOceanGateway, dev_id: AddressExpression, dev_name: str, dev_eep: EEP, event_id: str, key:str, convert_event_function, icon:str=None):
         super().__init__(platform, gateway,
-                         dev_id=dev_id, 
-                         dev_name=dev_name, 
+                         dev_id=dev_id,
+                         dev_name=dev_name,
                          dev_eep=dev_eep,
                          description=EltakoSensorEntityDescription(
                             key=key,
@@ -1003,15 +999,20 @@ class EventListenerInfoField(EltakoSensor):
                             has_entity_name= True,
                         )
         )
+        self._event_id = event_id
         self.convert_event_function = convert_event_function
         self._attr_name = key
         self._attr_native_value = ''
         self.listen_to_addresses.clear()
 
-        LOGGER.debug(f"[{platform}] [{EventListenerInfoField.__name__}] [{b2s(dev_id[0])}] [{key}] Register event: {event_id}")
-        self.hass.bus.async_listen(event_id, self.value_changed)
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to event when added to hass."""
+        await super().async_added_to_hass()
+        LOGGER.debug(f"[{self._attr_ha_platform}] [{EventListenerInfoField.__name__}] [{b2s(self.dev_id[0])}] [{self._attr_name}] Register event: {self._event_id}")
+        self.async_on_remove(
+            self.hass.bus.async_listen(self._event_id, self.value_changed)
+        )
 
-    
     def value_changed(self, event) -> None:
         LOGGER.debug(f"Received event: {event}")
         self.native_value = self.convert_event_function(event)

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -22,14 +22,23 @@ class BusMock():
             'context': context
         })
 
+class LoopMock():
+    """Mock event loop that executes callbacks directly."""
+
+    def call_soon_threadsafe(self, callback, *args):
+        callback(*args)
+
 class HassMock():
-        
+
     def __init__(self) -> None:
         self.bus = BusMock()
-        self.loop = asyncio.get_event_loop()
+        self.loop = LoopMock()
+        self._tasks = []
 
-    # def async_create_task(self, async_call):
-    #     asyncio.run( async_call )
+    def create_task(self, coro):
+        # Close the coroutine to avoid warnings - tests don't actually run async
+        coro.close()
+        return None
         
 class ConfigEntryMock():
 

--- a/tests/test_device_entity.py
+++ b/tests/test_device_entity.py
@@ -28,8 +28,8 @@ class TestEntityProperties(unittest.TestCase):
 
         self.assertEqual(ee.dev_name, config_helpers.get_device_name(name, address, gw.general_settings))
         
-        self.assertEqual(len(ee.listen_to_addresses),1)
-        self.assertEqual(ee.listen_to_addresses[0], b'\xfe4!\x01')
+        self.assertEqual(len(ee.listen_to_addresses), 1)
+        self.assertIn(b'\xfe4!\x01', ee.listen_to_addresses)
 
         self.assertEqual(ee.dev_name, 'Switch')
         self.assertEqual(ee.unique_id, 'eltako_gw123_fe_34_21_01')

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -25,10 +25,9 @@ class TestGateway(TestCase):
     def test_gateway_creation(self):
         sub_type = GatewayDeviceType.GatewayEltakoFAM14
         baud_rate = BAUD_RATE_DEVICE_TYPE_MAPPING[sub_type]
-        conf = ConfigEntry(version=1, minor_version=0, domain=DOMAIN, title="gateway", data={}, source=None, options=None, unique_id=None)
-        gw = EnOceanGateway(DEFAULT_GENERAL_SETTINGS, HassMock(), 
+        gw = EnOceanGateway(DEFAULT_GENERAL_SETTINGS, HassMock(),
                               dev_id=123, dev_type=sub_type, serial_path="serial_path",  baud_rate=baud_rate, port=None, base_id=AddressExpression.parse('FF-AA-00-00'), dev_name="GW", auto_reconnect=True,
-                              config_entry=conf)
+                              config_entry=ConfigEntryMock())
         
         self.assertEqual(gw.identifier, basename(normpath('serial_path')))
         self.assertEqual(gw.general_settings, DEFAULT_GENERAL_SETTINGS)


### PR DESCRIPTION
Hey @grimmpp,

I ran into stability issues with v1.x on my Home Assistant running the latest 2026.x release. With my FGW14-USB connected, the entire HA installation stopped responding. Even lowering log levels didn't help. So I dug deeper, and this PR contains what I found.

The root causes I found so far:

- high-volume serial telegrams were broadcast to every entity (O(N) fan-out)
- blocking calls on the event loop (time.sleep, bus.join)
- thread-unsafe calls from the serial thread
- and listener/task leaks on reload

On HA 2026.x, the "Messages" unit also caused validation errors, which you already fixed in f3c40199bc41ca251aed0992bbbdd5674e57f400 but it's not part of 1.x yet. This PR additionally removes `suggested_unit_of_measurement` (invalid when there’s no device class) and leaves the unit unset to avoid HA 2026.x validation errors. See https://github.com/home-assistant/core/pull/151912. I'm not sure if this is actually the right fix, happy to hear your opinion on that.

This PR focuses on stability first (no blocking, no thread-unsafe calls) and performance second (cut fan-out, reduce allocations).

:exclamation: This branch targets `feature-branch-v1`, I haven't checked the current `main` (v2) branch for similar issues as my agenda was to get my own Eltako installation running first :see_no_evil: If this proves helpful, I can do a similar rundown on `main` too.

**Thread safety fixes**

The serial thread was calling HA APIs directly, which can cause random lockups. HA has a single event loop thread, and calling into it from other threads without synchronization is asking for trouble. The fix is to use `call_soon_threadsafe` to hand off work to the event loop, which is the standard pattern for this.

For `send_message`, I switched from `async_dispatcher_send` to the sync `dispatcher_send`. Sync entity methods can end up running in executor threads, and `dispatcher_send` is explicitly documented as thread-safe while `async_dispatcher_send` must only be called from the event loop. I was getting `RuntimeErrors` on HA 2026.x before this change.

The reconnect and unload logic had a similar problem. `bus.join()` is blocking and was running directly on the event loop. Now it runs via `async_add_executor_job` so HA stays responsive during reconnects. Same fix for cover tilt, which was using `time.sleep()` instead of `await asyncio.sleep()`.

See: https://developers.home-assistant.io/docs/asyncio_thread_safety/, https://developers.home-assistant.io/docs/asyncio_blocking_operations/

**Address-scoped dispatch**

This was probably the biggest win. Previously, every telegram triggered callbacks on all entities, and each entity was then filtered by address. With lots of entities, that's O(N) work per telegram, which adds up fast.

The fix is to bake the source address into the event ID (`eltako.gw_X.receive_message.sid_00-00-00-XX`) and have each entity subscribe only to the addresses it cares about. The old broadcast-then-filter model is gone.

I had to normalize listen addresses before building event IDs. Raw bytes get wrapped into an `AddressExpression`-compatible tuple so thermostat IDs and similar cases don't break subscriptions.

Since state updates are now fully event-driven, I set `_attr_should_poll = False`. Polling was just adding unnecessary overhead.

**Lifecycle cleanup**

The cooling switch listener in `climate.py` was set up without storing the unsubscribe handle, which leaks listeners across reloads. I moved it to `async_added_to_hass` and registered it with `async_on_remove`. Also added `async_will_remove_from_hass` to properly cancel the periodic update task.

Same fix for `EventListenerInfoField` in `sensor.py`.

**Smaller fixes**

- Gateway stats: Throttled to once per second. No need to update "last message received" on every telegram.
- ID validation: FE/FF wireless sender IDs no longer trigger spurious warnings.
- HA 2026.x unit validation: Removed `suggested_unit_of_measurement` (invalid when there's no device class). `unit_of_measurement` is now unset as well. See https://github.com/home-assistant/core/pull/151912.
- Hot-path cleanup: `_HANDLED_MSG_TYPES` is now a class-level tuple, `listen_to_addresses` is a set, removed `json.dumps` from the `binary_sensor` debug path, removed `.serialize().hex()` from gateway debug logs.
- Sender-ID validation: `validate_sender_id` now actually uses its argument.