### PR TITLE
Bump esp2_gateway_adapter to 0.2.21 (fixes ESP3 receive-thread crash)

### DIFF
--- a/custom_components/eltako/manifest.json
+++ b/custom_components/eltako/manifest.json
@@ -10,6 +10,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/grimmpp/home-assistant-eltako/issues",
   "loggers": ["eltako"],
-  "requirements": ["eltako14bus==0.0.73", "enocean>=0.60.1", "StrEnum", "esp2_gateway_adapter==0.2.15"],
+  "requirements": ["eltako14bus==0.0.73", "enocean>=0.60.1", "StrEnum", "esp2_gateway_adapter==0.2.21"],
   "version": "2.0.0" 
 }


### PR DESCRIPTION
### What
Bumps the pinned dependency `esp2_gateway_adapter` from `0.2.15` to `0.2.21` in `custom_components/eltako/manifest.json`.

### Why
With a USB300 (ESP3 gateway) the receive thread crashes on 0.2.15: AttributeError: 'RadioPacket' object has no attribute 'response' in esp2_gateway_adapter/esp3_serial_com.py, convert_esp3_to_esp2_message

`convert_esp3_to_esp2_message` accesses `packet.response` without checking the packet type, so incoming `RadioPacket`s raise. This breaks status feedback and makes teach-in unreliable. `esp2_gateway_adapter` 0.2.21 ("Bug in converting esp3 to esp2 message") fixes it; bumping the pin and restarting HA resolved it on my setup (HA on Python 3.14, integration v2.0.0). Related to #185.