### PR TITLE
Handle unknown cover positions defensively

### DIFF
--- a/custom_components/eltako/cover.py
+++ b/custom_components/eltako/cover.py
@@ -21,6 +21,15 @@ from .const import CONF_SENDER, CONF_TIME_CLOSES, CONF_TIME_OPENS, CONF_TIME_TIL
 from . import get_gateway_from_hass, get_device_config_for_gateway
 import time
 
+
+def _coerce_position(value: Any) -> int | None:
+    """Return a cover position clamped to the Home Assistant range."""
+    try:
+        return max(0, min(100, int(value)))
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: config_entries.ConfigEntry,
@@ -82,42 +91,39 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
 
 
     def load_value_initially(self, latest_state:State):
-        # LOGGER.debug(f"[cover {self.dev_id}] latest state: {latest_state.state}")
-        # LOGGER.debug(f"[cover {self.dev_id}] latest state attributes: {latest_state.attributes}")
-        try:
-            self._attr_current_cover_position = latest_state.attributes['current_position']
-            self._attr_current_cover_tilt_position = latest_state.attributes['current_tilt_position']
+        attrs = latest_state.attributes or {}
 
-            #if self._attr_current_cover_tilt_position == 0:
-            #    self._attr_current_cover_tilt_position = 0
-            if latest_state.state == STATE_OPEN:
-                self._attr_is_opening = False
-                self._attr_is_closing = False
-                self._attr_is_closed = False
-                self._attr_current_cover_position = 100
-                self._attr_current_cover_tilt_position = 100
-            elif latest_state.state == STATE_CLOSED:
-                self._attr_is_opening = False
-                self._attr_is_closing = False
-                self._attr_is_closed = True
-                self._attr_current_cover_position = 0
-                self._attr_current_cover_tilt_position = 0
-            elif latest_state.state == STATE_CLOSING:
-                self._attr_is_opening = False
-                self._attr_is_closing = True
-                self._attr_is_closed = False
-            elif latest_state.state == STATE_OPENING:
-                self._attr_is_opening = True
-                self._attr_is_closing = False
-                self._attr_is_closed = False
-            
-        except Exception as e:
-            self._attr_current_cover_position = None
-            self._attr_current_cover_tilt_position = None
-            self._attr_is_opening = None
-            self._attr_is_closing = None
-            self._attr_is_closed = None # means undefined state
-            # raise e
+        position = attrs.get('current_position')
+        if position is None:
+            position = attrs.get('current_cover_position')
+
+        tilt_position = attrs.get('current_tilt_position')
+        if tilt_position is None:
+            tilt_position = attrs.get('current_cover_tilt_position')
+
+        self._attr_current_cover_position = _coerce_position(position)
+        self._attr_current_cover_tilt_position = _coerce_position(tilt_position)
+
+        if latest_state.state == STATE_OPEN:
+            self._attr_is_opening = False
+            self._attr_is_closing = False
+            self._attr_is_closed = False
+            self._attr_current_cover_position = 100
+            self._attr_current_cover_tilt_position = 100
+        elif latest_state.state == STATE_CLOSED:
+            self._attr_is_opening = False
+            self._attr_is_closing = False
+            self._attr_is_closed = True
+            self._attr_current_cover_position = 0
+            self._attr_current_cover_tilt_position = 0
+        elif latest_state.state == STATE_CLOSING:
+            self._attr_is_opening = False
+            self._attr_is_closing = True
+            self._attr_is_closed = False
+        elif latest_state.state == STATE_OPENING:
+            self._attr_is_opening = True
+            self._attr_is_closing = False
+            self._attr_is_closed = False
         
         self.schedule_update_ha_state()
         LOGGER.debug(f"[cover {self.dev_id}] value initially loaded: [" 
@@ -186,9 +192,15 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
             return
         
         address, _ = self._sender_id
-        position = kwargs[ATTR_POSITION]
+        position = _coerce_position(kwargs.get(ATTR_POSITION))
+        if position is None:
+            LOGGER.warning("[%s %s] Invalid target cover position: %s", Platform.COVER, str(self.dev_id), kwargs.get(ATTR_POSITION))
+            return
+
+        current_position = _coerce_position(self._attr_current_cover_position)
+        self._attr_current_cover_position = current_position
         
-        if position == self._attr_current_cover_position:
+        if position == current_position:
             return
         elif position == 100:
             direction = "up"
@@ -196,19 +208,22 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
         elif position == 0:
             direction = "down"
             time = self._time_closes + 1
-        elif position > self._attr_current_cover_position:
+        elif current_position is None:
+            LOGGER.warning("[%s %s] Cannot set intermediate position %s because the current position is unknown.", Platform.COVER, str(self.dev_id), position)
+            return
+        elif position > current_position:
             direction = "up"
-            time = max(1,min(int(((position - self._attr_current_cover_position) / 100.0) * self._time_opens), 255))
+            time = max(1,min(int(((position - current_position) / 100.0) * self._time_opens), 255))
             # try to prevent covers moving completely up or down when time = 0
-        elif position < self._attr_current_cover_position:
+        else:
             direction = "down"
-            time = max(1,min(int(((self._attr_current_cover_position - position) / 100.0) * self._time_closes), 255))
+            time = max(1,min(int(((current_position - position) / 100.0) * self._time_closes), 255))
             # try to prevent covers moving completely up or down when time = 0
 
         if self._sender_eep == H5_3F_7F:
             if direction == "up":
                 command = 0x01
-            elif direction == "down":
+            else:
                 command = 0x02
             
             msg = H5_3F_7F(time, command, 1).encode_message(address)
@@ -222,7 +237,7 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
             if direction == "up":
                 self._attr_is_opening = True
                 self._attr_is_closing = False
-            elif direction == "down":
+            else:
                 self._attr_is_closing = True
                 self._attr_is_opening = False
                 
@@ -294,6 +309,8 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
                     
                     self._attr_current_cover_position = min(self._attr_current_cover_position + int(time_in_seconds / self._time_opens * 100.0), 100)
                     if self._time_tilts is not None:
+                        if self._attr_current_cover_tilt_position is None:
+                            self._attr_current_cover_tilt_position = 0
                         self._attr_current_cover_tilt_position = min(self._attr_current_cover_tilt_position + int(decoded.time / self._time_tilts * 100.0), 100)
 
                 else:  # down
@@ -305,6 +322,8 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
                     
                     self._attr_current_cover_position = max(self._attr_current_cover_position - int(time_in_seconds / self._time_closes * 100.0), 0)
                     if self._time_tilts is not None:
+                        if self._attr_current_cover_tilt_position is None:
+                            self._attr_current_cover_tilt_position = 100
                         self._attr_current_cover_tilt_position = max(self._attr_current_cover_tilt_position - int(decoded.time / self._time_tilts * 100.0), 0)
 
                 if self._attr_current_cover_position == 0:
@@ -323,22 +342,34 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
 
 
     def set_cover_tilt_position(self, **kwargs: Any) -> None:
-        address, _ = self._sender_id
-        tilt_position = kwargs[ATTR_TILT_POSITION]
-        
-        if tilt_position == self._attr_current_cover_tilt_position:
+        if self._time_tilts is None:
             return
-        elif tilt_position > self._attr_current_cover_tilt_position:
+
+        address, _ = self._sender_id
+        tilt_position = _coerce_position(kwargs.get(ATTR_TILT_POSITION))
+        if tilt_position is None:
+            LOGGER.warning("[%s %s] Invalid target cover tilt position: %s", Platform.COVER, str(self.dev_id), kwargs.get(ATTR_TILT_POSITION))
+            return
+
+        current_tilt_position = _coerce_position(self._attr_current_cover_tilt_position)
+        self._attr_current_cover_tilt_position = current_tilt_position
+        if current_tilt_position is None:
+            LOGGER.warning("[%s %s] Cannot set tilt position %s because the current tilt position is unknown.", Platform.COVER, str(self.dev_id), tilt_position)
+            return
+        
+        if tilt_position == current_tilt_position:
+            return
+        elif tilt_position > current_tilt_position:
             direction = "up"
-            sleeptime = min((((tilt_position - self._attr_current_cover_tilt_position) / 100.0 * self._time_tilts / 10.0) ), 255.0)
-        elif tilt_position < self._attr_current_cover_tilt_position:
+            sleeptime = min((((tilt_position - current_tilt_position) / 100.0 * self._time_tilts / 10.0) ), 255.0)
+        else:
             direction = "down"
-            sleeptime = min((((self._attr_current_cover_tilt_position - tilt_position) / 100.0 * self._time_tilts / 10.0) ), 255.0)
+            sleeptime = min((((current_tilt_position - tilt_position) / 100.0 * self._time_tilts / 10.0) ), 255.0)
 
         if self._sender_eep == H5_3F_7F:
             if direction == "up":
                 command = 0x01
-            elif direction == "down":
+            else:
                 command = 0x02
             
             msg = H5_3F_7F(0, command, 1).encode_message(address)
@@ -353,6 +384,6 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
             if direction == "up":
                 self._attr_is_opening = True
                 self._attr_is_closing = False
-            elif direction == "down":
+            else:
                 self._attr_is_closing = True
                 self._attr_is_opening = False

--- a/tests/test_cover_defensive_state.py
+++ b/tests/test_cover_defensive_state.py
@@ -1,0 +1,154 @@
+import unittest
+from unittest import mock
+
+from eltakobus import AddressExpression, EEP, Regular4BSMessage
+from homeassistant.const import Platform
+from homeassistant.helpers.entity import Entity
+
+from custom_components.eltako.config_helpers import (
+    CONF_FAST_STATUS_CHANGE,
+    DEFAULT_GENERAL_SETTINGS,
+)
+from custom_components.eltako.cover import EltakoCover
+from tests.mocks import GatewayMock, LatestStateMock
+
+
+Entity.schedule_update_ha_state = mock.Mock(return_value=None)
+
+
+class TestDefensiveCoverState(unittest.TestCase):
+    def setUp(self):
+        self.last_sent_command = None
+
+    def _capture_message(self, msg):
+        self.last_sent_command = msg
+
+    def _create_cover(self, *, with_tilt=False):
+        settings = DEFAULT_GENERAL_SETTINGS.copy()
+        settings[CONF_FAST_STATUS_CHANGE] = True
+        gateway = GatewayMock(settings)
+        cover = EltakoCover(
+            Platform.COVER,
+            gateway,
+            AddressExpression.parse("00-00-00-01"),
+            "device name",
+            EEP.find("G5-3F-7F"),
+            AddressExpression.parse("00-00-B1-07"),
+            EEP.find("H5-3F-7F"),
+            "blind" if with_tilt else "shutter",
+            10,
+            10,
+            15 if with_tilt else None,
+        )
+        cover.send_message = self._capture_message
+        return cover
+
+    def test_restore_missing_tilt_attribute_keeps_cover_state(self):
+        cover = self._create_cover()
+
+        cover.load_value_initially(
+            LatestStateMock("opening", {"current_position": 55})
+        )
+
+        self.assertEqual(cover.current_cover_position, 55)
+        self.assertIsNone(cover.current_cover_tilt_position)
+        self.assertTrue(cover.is_opening)
+        self.assertFalse(cover.is_closing)
+        self.assertFalse(cover.is_closed)
+
+    def test_restore_missing_position_attribute_keeps_motion_state(self):
+        cover = self._create_cover(with_tilt=True)
+
+        cover.load_value_initially(
+            LatestStateMock("closing", {"current_tilt_position": 10})
+        )
+
+        self.assertIsNone(cover.current_cover_position)
+        self.assertEqual(cover.current_cover_tilt_position, 10)
+        self.assertFalse(cover.is_opening)
+        self.assertTrue(cover.is_closing)
+        self.assertFalse(cover.is_closed)
+
+    def test_restore_invalid_values_are_ignored_and_bounds_are_clamped(self):
+        cover = self._create_cover(with_tilt=True)
+
+        cover.load_value_initially(
+            LatestStateMock(
+                "opening",
+                {
+                    "current_position": "unknown",
+                    "current_tilt_position": 125,
+                },
+            )
+        )
+
+        self.assertIsNone(cover.current_cover_position)
+        self.assertEqual(cover.current_cover_tilt_position, 100)
+
+        cover.load_value_initially(
+            LatestStateMock(
+                "closing",
+                {
+                    "current_position": -5,
+                    "current_tilt_position": 20,
+                },
+            )
+        )
+        self.assertEqual(cover.current_cover_position, 0)
+        self.assertEqual(cover.current_cover_tilt_position, 20)
+
+    def test_intermediate_target_is_ignored_when_current_position_is_unknown(self):
+        cover = self._create_cover()
+        cover._attr_current_cover_position = None
+
+        cover.set_cover_position(position=50)
+
+        self.assertIsNone(self.last_sent_command)
+        self.assertIsNone(cover.current_cover_position)
+
+    def test_end_positions_work_when_current_position_is_unknown(self):
+        cover = self._create_cover()
+        cover._attr_current_cover_position = None
+
+        cover.set_cover_position(position=100)
+        self.assertEqual(
+            self.last_sent_command.body,
+            b"k\x07\x00\x0b\x01\x08\x00\x00\xb1\x07\x00",
+        )
+
+        self.last_sent_command = None
+        cover._attr_current_cover_position = None
+        cover.set_cover_position(position=0)
+        self.assertEqual(
+            self.last_sent_command.body,
+            b"k\x07\x00\x0b\x02\x08\x00\x00\xb1\x07\x00",
+        )
+
+    def test_intermediate_telegram_initializes_unknown_tilt_position(self):
+        cover = self._create_cover(with_tilt=True)
+        cover._attr_current_cover_position = 10
+        cover._attr_current_cover_tilt_position = None
+        msg = Regular4BSMessage(
+            address=b"\x00\x00\x00\x01",
+            status=b"\x20",
+            data=b"\x00\x1e\x01\x0a",
+            outgoing=False,
+        )
+
+        cover.value_changed(msg)
+
+        self.assertEqual(cover.current_cover_position, 40)
+        self.assertEqual(cover.current_cover_tilt_position, 100)
+
+    def test_tilt_target_is_ignored_when_current_tilt_is_unknown(self):
+        cover = self._create_cover(with_tilt=True)
+        cover._attr_current_cover_tilt_position = None
+
+        cover.set_cover_tilt_position(tilt_position=50)
+
+        self.assertIsNone(self.last_sent_command)
+        self.assertIsNone(cover.current_cover_tilt_position)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cover_defensive_state.py
+++ b/tests/test_cover_defensive_state.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest
 from unittest import mock
 
@@ -18,7 +19,13 @@ Entity.schedule_update_ha_state = mock.Mock(return_value=None)
 
 class TestDefensiveCoverState(unittest.TestCase):
     def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
         self.last_sent_command = None
+
+    def tearDown(self):
+        asyncio.set_event_loop(None)
+        self.loop.close()
 
     def _capture_message(self, msg):
         self.last_sent_command = msg


### PR DESCRIPTION
## Summary

This PR makes cover state restoration and position commands safe when Home Assistant has no valid current position.

It is based on a defensive patch used with an FGW14-USB gateway and FSB14 covers (G5-3F-7F / H5-3F-7F).

## Problems fixed

- `load_value_initially()` used hard dictionary lookups for both position attributes. If one attribute was missing, the broad exception handler discarded all otherwise usable state.
- `set_cover_position()` compared an integer target with `None` when the current position was unknown, raising `TypeError` for intermediate targets.
- Intermediate blind telegrams performed arithmetic with an unknown tilt position.
- `set_cover_tilt_position()` compared its target with `None` when the current tilt position was unknown.

## Changes

- Add a small position normalizer that converts values safely and clamps them to `0..100`.
- Restore position and tilt independently with `.get()` lookups.
- Accept both Home Assistant attribute names and compatibility aliases.
- Keep full open/close commands available when the current position is unknown.
- Reject intermediate targets with a warning when the current position is unknown instead of guessing or raising an exception.
- Initialize an unknown tilt position consistently when an intermediate status telegram supplies a known direction.
- Reject tilt target commands safely when the current tilt position is unknown.

## Tests

Adds regression tests for:

- missing restore attributes;
- invalid and out-of-range restored values;
- intermediate targets with unknown current position;
- full open/close targets with unknown current position;
- intermediate telegrams with unknown tilt state;
- tilt targets with unknown current tilt state.

The existing cover test module and the new regression tests pass on Python 3.14.

## Scope

This PR intentionally contains no gateway-event or automation-specific changes. Those are proposed separately so this bug fix can be reviewed independently.
