### PR TITLE
Fix meter sensors staying unavailable after restart, and gateway message counter

### DIFF
--- a/custom_components/eltako/sensor.py
+++ b/custom_components/eltako/sensor.py
@@ -914,9 +914,9 @@ class GatewayReceivedMessagesInActiveSession(EltakoSensor):
                             name="Received Messages per Session",
                             state_class=SensorStateClass.TOTAL_INCREASING,
                             # device_class=SensorDeviceClass.VOLUME,
-                            # native_unit_of_measurement="Messages", # => raises error message
-                            unit_of_measurement="count",
-                            suggested_unit_of_measurement="Messages",
+                            # No unit: "Messages" is not a valid unit of measurement and makes
+                            # Home Assistant refuse to add the entity. A unitless counter with
+                            # state_class TOTAL_INCREASING is valid.
                             icon="mdi:chart-line",
                         )
         )

--- a/custom_components/eltako/sensor.py
+++ b/custom_components/eltako/sensor.py
@@ -460,8 +460,8 @@ class EltakoSensor(EltakoEntity, RestoreEntity, SensorEntity):
         LOGGER.debug(f"[{self._attr_ha_platform} {self.dev_id}] latest state - state: {latest_state.state}")
         LOGGER.debug(f"[{self._attr_ha_platform} {self.dev_id}] latest state - attributes: {latest_state.attributes}")
         try:
-            if 'unknown' == latest_state.state:
-                self._attr_is_on = None
+            if latest_state.state in ['unknown', 'unavailable']:
+                self._attr_native_value = None
             else:
                 if latest_state.attributes.get('state_class', None) == 'measurement':
                     if latest_state.state.count('.') + latest_state.state.count(',') == 1:
@@ -472,18 +472,18 @@ class EltakoSensor(EltakoEntity, RestoreEntity, SensorEntity):
                         self._attr_native_value = None
 
                 elif latest_state.attributes.get('state_class', None) == 'total_increasing':
-                    self._attr_native_value = int(latest_state.state)
+                    # meter readings are decimals (e.g. '5793.4' kWh), int() would raise here
+                    self._attr_native_value = float(latest_state.state)
 
                 elif latest_state.attributes.get('device_class', None) == 'device_class':
                     # e.g.: 2024-02-12T23:32:44+00:00
                     self._attr_native_value = datetime.strptime(latest_state.state, '%Y-%m-%dT%H:%M:%S%z:%f')
-            
+
         except Exception as e:
-            if hasattr(self, '_attr_is_on'):
-                self._attr_is_on = None
-            elif hasattr(self, '_attr_native_value'):
-                self._attr_native_value = None
-            raise e
+            self._attr_native_value = None
+            # do not re-raise: an unparsable stored state must not abort async_added_to_hass,
+            # otherwise the entity is never added and stays unavailable until the next restart
+            LOGGER.warning(f"[{self._attr_ha_platform} {self.dev_id}] Could not restore previous state '{latest_state.state}': {e}")
         
         self.schedule_update_ha_state()
 


### PR DESCRIPTION
Two independent defects in `custom_components/eltako/sensor.py`, both causing entities to never be added to Home Assistant. Found and fixed on a live installation (7× FWZ14 meters, EnOcean USB300 gateway).

---

## 1. Cumulative meter sensors permanently `unavailable`

All `electricity_cumulative` sensors (A5-12-01, FWZ14) were `unavailable` after every restart, while the corresponding power sensors kept working.

`EltakoSensor.load_value_initially()` parses the restored state of `total_increasing` sensors with `int()`. Meter readings have 0.1 kWh resolution, so the stored state is a decimal string:

```
File "custom_components/eltako/sensor.py", line 475, in load_value_initially
    self._attr_native_value = int(latest_state.state)
ValueError: invalid literal for int() with base 10: '5793.4'
→ Error adding entity sensor.eltako_gw3_ff_93_00_1b_electricity_cumulative  (×7)
```

The `except` block re-raises, and because `load_value_initially()` is called from `async_added_to_hass()`, Home Assistant aborts adding the entity entirely. The same crash then repeats on every restart.

**Fix:**
- parse `total_increasing` states with `float()` instead of `int()`
- log a warning instead of re-raising, so an unparsable stored state can never prevent an entity from being added
- treat `'unavailable'` like `'unknown'` (both are non-parsable pseudo states)

The `except` branch also assigned `_attr_is_on`, which does not exist on a sensor entity; it now consistently resets `_attr_native_value`.

**Verified:** after the change all 7 cumulative sensors restore their previous reading and update with the next telegram (e.g. 3078.0 kWh, matching the value the ioBroker EnOcean adapter reports for the same meter).

---

## 2. `Received Messages per Session` entity never created

```
ValueError: Entity <class '...GatewayReceivedMessagesInActiveSession'>
            suggest an incorrect unit of measurement: Messages.
→ Error adding entity sensor.eltako_gw3_..._received_messages_per_session
```

"Messages" is not a valid unit of measurement, and recent Home Assistant versions validate `suggested_unit_of_measurement` too. The existing code comment shows the invalid unit was already known to break `native_unit_of_measurement`; moving it to the suggested/unit fields only postponed the problem.

**Fix:** drop the unit fields — a unitless counter with `state_class=TOTAL_INCREASING` is valid.

**Verified:** the entity is now created and counts received telegrams.

> **Note on scope:** this was reproduced and verified on v1.5.10, where both `unit_of_measurement` and `suggested_unit_of_measurement` were `"Messages"`. On `main`, `unit_of_measurement` has since been changed to `"count"`, but `suggested_unit_of_measurement="Messages"` — the field named in the traceback — is still present, so the defect should persist. I was not able to run `main` itself.

---

## Testing

`python -m unittest discover tests` gives identical results before and after these changes (the remaining failures are missing dependencies in my environment, not regressions).
