### PR TITLE
Fix cover position persistence, sensor restore, and telegram collisions

### DIFF
--- a/custom_components/eltako/cover.py
+++ b/custom_components/eltako/cover.py
@@ -82,26 +82,26 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
 
 
     def load_value_initially(self, latest_state:State):
-        # LOGGER.debug(f"[cover {self.dev_id}] latest state: {latest_state.state}")
-        # LOGGER.debug(f"[cover {self.dev_id}] latest state attributes: {latest_state.attributes}")
         try:
-            self._attr_current_cover_position = latest_state.attributes['current_position']
-            self._attr_current_cover_tilt_position = latest_state.attributes['current_tilt_position']
+            self._attr_current_cover_position = latest_state.attributes.get('current_position', None)
+            self._attr_current_cover_tilt_position = latest_state.attributes.get('current_tilt_position', None)
 
-            #if self._attr_current_cover_tilt_position == 0:
-            #    self._attr_current_cover_tilt_position = 0
             if latest_state.state == STATE_OPEN:
                 self._attr_is_opening = False
                 self._attr_is_closing = False
                 self._attr_is_closed = False
-                self._attr_current_cover_position = 100
-                self._attr_current_cover_tilt_position = 100
+                if self._attr_current_cover_position is None:
+                    self._attr_current_cover_position = 100
+                if self._attr_current_cover_tilt_position is None:
+                    self._attr_current_cover_tilt_position = 100
             elif latest_state.state == STATE_CLOSED:
                 self._attr_is_opening = False
                 self._attr_is_closing = False
                 self._attr_is_closed = True
-                self._attr_current_cover_position = 0
-                self._attr_current_cover_tilt_position = 0
+                if self._attr_current_cover_position is None:
+                    self._attr_current_cover_position = 0
+                if self._attr_current_cover_tilt_position is None:
+                    self._attr_current_cover_tilt_position = 0
             elif latest_state.state == STATE_CLOSING:
                 self._attr_is_opening = False
                 self._attr_is_closing = True
@@ -110,14 +110,14 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
                 self._attr_is_opening = True
                 self._attr_is_closing = False
                 self._attr_is_closed = False
-            
+
         except Exception as e:
             self._attr_current_cover_position = None
             self._attr_current_cover_tilt_position = None
             self._attr_is_opening = None
             self._attr_is_closing = None
-            self._attr_is_closed = None # means undefined state
-            # raise e
+            self._attr_is_closed = None
+            LOGGER.warning(f"[cover {self.dev_id}] Failed to restore state: {e}")
         
         self.schedule_update_ha_state()
         LOGGER.debug(f"[cover {self.dev_id}] value initially loaded: [" 
@@ -184,11 +184,18 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
         """Move the cover to a specific position."""
         if self._time_closes is None or self._time_opens is None:
             return
-        
+
         address, _ = self._sender_id
         position = kwargs[ATTR_POSITION]
-        
-        if position == self._attr_current_cover_position:
+
+        if self._attr_current_cover_position is None:
+            if position >= 50:
+                direction = "up"
+                time = self._time_opens + 1
+            else:
+                direction = "down"
+                time = self._time_closes + 1
+        elif position == self._attr_current_cover_position:
             return
         elif position == 100:
             direction = "up"
@@ -199,11 +206,9 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
         elif position > self._attr_current_cover_position:
             direction = "up"
             time = max(1,min(int(((position - self._attr_current_cover_position) / 100.0) * self._time_opens), 255))
-            # try to prevent covers moving completely up or down when time = 0
         elif position < self._attr_current_cover_position:
             direction = "down"
             time = max(1,min(int(((self._attr_current_cover_position - position) / 100.0) * self._time_closes), 255))
-            # try to prevent covers moving completely up or down when time = 0
 
         if self._sender_eep == H5_3F_7F:
             if direction == "up":
@@ -294,6 +299,8 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
                     
                     self._attr_current_cover_position = min(self._attr_current_cover_position + int(time_in_seconds / self._time_opens * 100.0), 100)
                     if self._time_tilts is not None:
+                        if self._attr_current_cover_tilt_position is None:
+                            self._attr_current_cover_tilt_position = 0
                         self._attr_current_cover_tilt_position = min(self._attr_current_cover_tilt_position + int(decoded.time / self._time_tilts * 100.0), 100)
 
                 else:  # down
@@ -302,9 +309,11 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
                     # the initial position.
                     if self._attr_current_cover_position is None:
                         self._attr_current_cover_position = 100
-                    
+
                     self._attr_current_cover_position = max(self._attr_current_cover_position - int(time_in_seconds / self._time_closes * 100.0), 0)
                     if self._time_tilts is not None:
+                        if self._attr_current_cover_tilt_position is None:
+                            self._attr_current_cover_tilt_position = 100
                         self._attr_current_cover_tilt_position = max(self._attr_current_cover_tilt_position - int(decoded.time / self._time_tilts * 100.0), 0)
 
                 if self._attr_current_cover_position == 0:
@@ -325,8 +334,14 @@ class EltakoCover(EltakoEntity, CoverEntity, RestoreEntity):
     def set_cover_tilt_position(self, **kwargs: Any) -> None:
         address, _ = self._sender_id
         tilt_position = kwargs[ATTR_TILT_POSITION]
-        
-        if tilt_position == self._attr_current_cover_tilt_position:
+
+        if self._attr_current_cover_tilt_position is None:
+            if tilt_position >= 50:
+                direction = "up"
+            else:
+                direction = "down"
+            sleeptime = min((self._time_tilts / 10.0), 255.0)
+        elif tilt_position == self._attr_current_cover_tilt_position:
             return
         elif tilt_position > self._attr_current_cover_tilt_position:
             direction = "up"

--- a/custom_components/eltako/gateway.py
+++ b/custom_components/eltako/gateway.py
@@ -92,6 +92,8 @@ class EnOceanGateway:
 
         self._reading_memory_of_devices_is_running = threading.Event()
 
+        self._send_lock = asyncio.Lock()
+
         self._init_bus()
 
         self._register_device()
@@ -233,7 +235,7 @@ class EnOceanGateway:
     def dev_id_validation_by_transmitter(self, dev_id: AddressExpression, device_name: str = "") -> bool:
         result = 0xFF == dev_id[0][0]
         if not result:
-            LOGGER.warning(f"{device_name} ({dev_id}): Maybe have wrong device id configured!")
+            LOGGER.info(f"{device_name} ({dev_id}): Device id does not start with 0xFF — likely a wirelessly paired device.")
         return result
     
 
@@ -366,13 +368,19 @@ class EnOceanGateway:
             if isinstance(msg, ESP2Message):
                 LOGGER.debug("[Gateway] [Id: %d] Send message: %s - Serialized: %s", self.dev_id, msg, msg.serialize().hex())
 
-                # put message on serial bus
                 self.hass.create_task(
-                    self._bus.send(msg)
+                    self._async_send_with_delay(msg)
                 )
                 dispatcher_send(self.hass, ELTAKO_GLOBAL_EVENT_BUS_ID, {'gateway':self, 'esp2_msg': msg})
         else:
             LOGGER.warning("[Gateway] [Id: %d] Serial port %s is not available!!! message (%s) was not sent.", self.dev_id, self.serial_path, msg)
+
+    async def _async_send_with_delay(self, msg):
+        """Send message to serial bus with delay to prevent telegram collisions."""
+        async with self._send_lock:
+            await self._bus.send(msg)
+            if self._message_delay and self._message_delay > 0:
+                await asyncio.sleep(self._message_delay)
 
 
     def _callback_receive_message_from_serial_bus(self, message:ESP2Message):

--- a/custom_components/eltako/sensor.py
+++ b/custom_components/eltako/sensor.py
@@ -472,7 +472,7 @@ class EltakoSensor(EltakoEntity, RestoreEntity, SensorEntity):
                         self._attr_native_value = None
 
                 elif latest_state.attributes.get('state_class', None) == 'total_increasing':
-                    self._attr_native_value = int(latest_state.state)
+                    self._attr_native_value = int(float(latest_state.state))
 
                 elif latest_state.attributes.get('device_class', None) == 'device_class':
                     # e.g.: 2024-02-12T23:32:44+00:00
@@ -914,9 +914,7 @@ class GatewayReceivedMessagesInActiveSession(EltakoSensor):
                             name="Received Messages per Session",
                             state_class=SensorStateClass.TOTAL_INCREASING,
                             # device_class=SensorDeviceClass.VOLUME,
-                            # native_unit_of_measurement="Messages", # => raises error message
-                            unit_of_measurement="count",
-                            suggested_unit_of_measurement="Messages",
+                            native_unit_of_measurement=None,
                             icon="mdi:chart-line",
                         )
         )


### PR DESCRIPTION
## Summary

- **cover.py (#200):** Preserve saved cover position/tilt on HA restart instead of overwriting with defaults. Add None guards in `set_cover_position`, `set_cover_tilt_position`, and `value_changed` to prevent `TypeError` crashes when position is unknown.
- **sensor.py (#175):** Use `int(float(latest_state.state))` instead of `int()` for `total_increasing` sensors to handle float string values like `"42.0"` that cause `ValueError` on restore.
- **sensor.py (#186):** Replace invalid `unit_of_measurement="count"` / `suggested_unit_of_measurement="Messages"` with `native_unit_of_measurement=None` to fix HA warnings about unsupported units.
- **gateway.py (#161):** Change misleading "Maybe have wrong device id" warning to an info-level message with clearer text for wirelessly paired devices.
- **gateway.py:** Add `asyncio.Lock` with `message_delay` support to serialize telegram sends and prevent collisions when multiple commands are sent simultaneously (e.g., closing 10+ covers at once).

## Related Issues

Fixes #200, #186, #175, #161

## Test plan

- [ ] Restart HA and verify cover positions are preserved from before restart
- [ ] Set cover position when current position is unknown (None) — should not crash
- [ ] Set cover tilt position when current tilt is unknown — should not crash
- [ ] Verify `total_increasing` sensors restore correctly with float state values
- [ ] Verify no HA warnings about `unit_of_measurement` for gateway message counter
- [ ] Send commands to multiple covers simultaneously — all should execute with delay
- [ ] Verify wirelessly paired devices log info instead of warning