### PR TITLE
Port Eltako integration fixes and clean warnings for v2.2.0rc2

### DIFF
--- a/custom_components/eltako/__init__.py
+++ b/custom_components/eltako/__init__.py
@@ -20,6 +20,14 @@ Home Assistant expects the setup functions in this file, so it only re-exports t
 See docs/architecture/readme.md for the guided tour.
 """
 import os
+import warnings
+
+# Suppress BeautifulSoup HTML parsing warning in third-party enocean library
+try:
+    from bs4 import XMLParsedAsHTMLWarning
+    warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
+except ImportError:
+    pass
 
 # Optionally do not load the integration init: when using e.g. const as a library in a different
 # project, the whole of Home Assistant would be loaded because it expects the setup functions in

--- a/custom_components/eltako/climate.py
+++ b/custom_components/eltako/climate.py
@@ -147,7 +147,7 @@ class ClimateController(EltakoEntity, ClimateEntity, RestoreEntity):
 
         self.thermostat = thermostat
         if self.thermostat:
-            self.listen_to_addresses.append(self.thermostat.id)
+            self.listen_to_addresses.append(self.thermostat.id[0])
 
         self.room_sensor_entity_id = room_sensor_entity_id
         self._room_sensor_temp = None
@@ -300,6 +300,8 @@ class ClimateController(EltakoEntity, ClimateEntity, RestoreEntity):
         if hvac_mode == HVACMode.OFF:
             if hvac_mode != self.hvac_mode:
                 self._send_mode_off()
+                self._attr_actuator_mode = A5_10_06.HeaterMode.OFF
+                self._send_command(self._attr_actuator_mode, self.target_temperature, self._attr_priority)
 
             # when cooling is active swtich from off to cooling
             elif self._get_mode() == HVACMode.COOL:
@@ -313,6 +315,8 @@ class ClimateController(EltakoEntity, ClimateEntity, RestoreEntity):
         elif hvac_mode == self._get_mode():
             self._attr_hvac_mode = hvac_mode
             self._send_set_normal_mode()
+            self._attr_actuator_mode = A5_10_06.HeaterMode.NORMAL
+            self._send_command(self._attr_actuator_mode, self.target_temperature, self._attr_priority)
 
 
     async def async_set_temperature(self, **kwargs) -> None:
@@ -337,12 +341,17 @@ class ClimateController(EltakoEntity, ClimateEntity, RestoreEntity):
     def _send_command(self, mode: A5_10_06.HeaterMode, target_temp: float, priority:A5_10_06.ControllerPriority) -> None:
         """Send command to set target temperature."""
         address, _ = self._sender_id
-        if target_temp is not None and 0 <= target_temp <= 40:
-            current_temp = 40
-            if self._room_sensor_temp is not None:
-                current_temp = self._room_sensor_temp
+        if target_temp is not None:
+            LOGGER.debug(f"[climate {self.dev_id}] Send status update: target temp: {target_temp}, mode: {mode}, priority: '{priority.description}'")
+            
+            # if current temperature is not available yet use 20°C as default
+            current_temp = self.current_temperature if self.current_temperature else 20
+            # Clamp current_temp to valid 0-40°C range to prevent ValueError in
+            # encode_message when stale bogus values (e.g. -9559.4) are loaded from HA state.
+            current_temp = max(0.0, min(40.0, float(current_temp)))
+            # Clamp target_temp as well to prevent out-of-range encoding
+            target_temp = max(float(self._attr_min_temp), min(float(self._attr_max_temp), float(target_temp)))
 
-            LOGGER.debug(f"[climate {self.dev_id}] Send status update: target temp: {target_temp}, current temp: {current_temp}, mode: {mode}, priority: '{priority.description}'")
             msg = A5_10_06(mode, target_temp, current_temp=current_temp, priority=priority).encode_message(address)
             self.send_message(msg)
         else:
@@ -461,9 +470,23 @@ class ClimateController(EltakoEntity, ClimateEntity, RestoreEntity):
 
     async def async_set_preset_mode(self, preset_mode):
         """Set new target preset mode."""
+        if preset_mode == PRESET_HOME:
+            self._attr_actuator_mode = A5_10_06.HeaterMode.NORMAL
+            self._send_set_normal_mode()
+        elif preset_mode == PRESET_ECO:
+            self._attr_actuator_mode = A5_10_06.HeaterMode.STAND_BY_2_DEGREES
+            self._send_mode_setback()
+        elif preset_mode == PRESET_SLEEP:
+            self._attr_actuator_mode = A5_10_06.HeaterMode.NIGHT_SET_BACK_4_DEGREES
+            self._send_mode_night()
+        else:
+            LOGGER.warning(f"[climate {self.dev_id}] Preset mode {preset_mode} not supported")
+            return
+
+        self._send_command(self._attr_actuator_mode, self.target_temperature, self._attr_priority)
 
         self._attr_preset_mode = preset_mode
-        self._send_command_to_change_mode_()
+        self.schedule_update_ha_state()
 
 
     def change_temperature_values(self, msg: ESP2Message) -> None:

--- a/custom_components/eltako/core/entity.py
+++ b/custom_components/eltako/core/entity.py
@@ -196,9 +196,7 @@ class EltakoEntity(Entity):
         """Handle incoming messages."""
         msg = data['esp2_msg']
 
-        msg_types = [EltakoWrappedRPS, EltakoWrapped1BS, EltakoWrapped4BS, RPSMessage, Regular1BSMessage, Regular4BSMessage]
-
-        if type(msg) in msg_types:
+        if hasattr(msg, 'address'):
             adr = AddressExpression((msg.address, None))
             if adr.is_local_address():
                 adr = adr.add(self.gateway.base_id)
@@ -206,7 +204,10 @@ class EltakoEntity(Entity):
             # LOGGER.debug(f"[{self.platform} {self.dev_id}] check if message address {b2s(msg.address)} is in registered list {', '.join([b2s(a) for a in self.listen_to_addresses])}")
             if adr[0] in self.listen_to_addresses:
                 ## TODO: filter out message sent twice through other gateways
-                self.value_changed(msg)
+                try:
+                    self.value_changed(msg)
+                except Exception as e:
+                    LOGGER.error("[%s %s] Error in value_changed: %s", self._attr_ha_platform, str(self.dev_id), str(e), exc_info=True)
 
 
     def value_changed(self, msg: ESP2Message):

--- a/custom_components/eltako/core/gateway.py
+++ b/custom_components/eltako/core/gateway.py
@@ -115,7 +115,7 @@ class EnOceanGateway:
         self._bus_task = None
         self.baud_rate = baud_rate
         self._auto_reconnect = auto_reconnect
-        self._message_delay = message_delay
+        self._message_delay = message_delay if message_delay is not None else 0.01
         self.port = port
         self._attr_dev_type = dev_type
         self._attr_serial_path = serial_path
@@ -450,6 +450,12 @@ class EnOceanGateway:
 
 
     def dev_id_validation_by_bus_gateway(self, dev_id: AddressExpression, device_name: str = "") -> bool:
+        # Bus actuators (F4SR14, FUD14, FSB14, F4HK14) always start with 00-00-xx-xx.
+        # Wireless devices (thermostats 05-xx, buttons FF-xx / FE-xx) are legitimately
+        # configured here as listeners only — skip the strict check for them.
+        if dev_id[0][0] != 0x00:
+            # Non-zero first byte → wireless/radio device, always valid in config.
+            return True
         result = config_helpers.compare_enocean_ids(b'\x00\x00\x00\x00', dev_id[0], len=2)
         if not result:
             LOGGER.warning(f"{device_name}: Device id {b2s(dev_id[0])} is not a local bus address; gateway "

--- a/custom_components/eltako/light.py
+++ b/custom_components/eltako/light.py
@@ -229,7 +229,7 @@ class EltakoSwitchableLight(AbstractLightEntity):
         address, _ = self._sender_id
 
         if self._sender_eep == A5_38_08:
-            switching = CentralCommandSwitching(0, 1, 0, 0, 1)
+            switching = CentralCommandSwitching(0, 1, 1, 0, 1)
             msg = A5_38_08(command=0x01, switching=switching).encode_message(address)
             self.send_message(msg)
 
@@ -263,7 +263,7 @@ class EltakoSwitchableLight(AbstractLightEntity):
         address, _ = self._sender_id
 
         if self._sender_eep == A5_38_08:
-            switching = CentralCommandSwitching(0, 1, 0, 0, 0)
+            switching = CentralCommandSwitching(0, 1, 1, 0, 0)
             msg = A5_38_08(command=0x01, switching=switching).encode_message(address)
             self.send_message(msg)
 

--- a/custom_components/eltako/switch.py
+++ b/custom_components/eltako/switch.py
@@ -101,7 +101,7 @@ class EltakoSwitch(EltakoEntity, SwitchEntity, RestoreEntity):
             self.send_message(released_msg)
 
         elif self._sender_eep == A5_38_08:
-            switching = CentralCommandSwitching(0, 1, 0, 0, 1)
+            switching = CentralCommandSwitching(0, 1, 1, 0, 1)
             msg = A5_38_08(command=0x01, switching=switching).encode_message(address)
             self.send_message(msg)
 
@@ -134,7 +134,7 @@ class EltakoSwitch(EltakoEntity, SwitchEntity, RestoreEntity):
             self.send_message(released_msg)
 
         elif self._sender_eep == A5_38_08:
-            switching = CentralCommandSwitching(0, 1, 0, 0, 0)
+            switching = CentralCommandSwitching(0, 1, 1, 0, 0)
             msg = A5_38_08(command=0x01, switching=switching).encode_message(address)
             self.send_message(msg)
 

--- a/custom_components/eltako/tools/plug_and_play.py
+++ b/custom_components/eltako/tools/plug_and_play.py
@@ -50,7 +50,7 @@ from datetime import datetime, timedelta, timezone
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
-from homeassistant.const import CONF_ID, CONF_NAME, Platform
+from homeassistant.const import CONF_ID, CONF_NAME, EVENT_HOMEASSISTANT_STARTED, Platform
 from homeassistant.core import HomeAssistant, callback
 
 from ..const import (CONF_BASE_ID, CONF_DEVICE_TYPE, CONF_EEP, CONF_GATEWAY, CONF_GATEWAY_ADDRESS,
@@ -1398,13 +1398,16 @@ async def async_setup_detection(hass: HomeAssistant, general_settings: dict) -> 
     if not is_enabled(general_settings):
         return
 
-    async def _initial_run() -> None:
+    async def _initial_run(event=None) -> None:
         # the gateways of the configuration connect first - their bus positions are needed to
         # decide which bus still has to be read
         await asyncio.sleep(STARTUP_DELAY)
         await async_run(hass)
 
-    hass.async_create_task(_initial_run())
+    if hass.is_running:
+        hass.async_create_task(_initial_run())
+    else:
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _initial_run)
 
 
 ### ---------------------------------------------------------------------------

--- a/tests/test_frontend_radio_page.py
+++ b/tests/test_frontend_radio_page.py
@@ -381,8 +381,11 @@ class TestRadioPage(unittest.TestCase):
         with open(outlier, 'w', encoding='utf-8') as handle:
             json.dump(build_outlier_report(), handle)
 
+        env = os.environ.copy()
+        env['LC_ALL'] = 'C.UTF-8'
+        env['LANG'] = 'C.UTF-8'
         process = subprocess.run([NODE, script, FRONTEND, report, outlier],
-                                 capture_output=True, text=True, timeout=120, cwd=REPO)
+                                 capture_output=True, text=True, env=env, timeout=120, cwd=REPO)
         assert process.returncode == 0, f"node failed:\n{process.stderr[-3000:]}"
         cls.result = json.loads(process.stdout)
 

--- a/tests/test_id_validation.py
+++ b/tests/test_id_validation.py
@@ -80,11 +80,11 @@ class TestActuatorIdValidation(unittest.TestCase):
 
     def test_wireless_id_on_a_bus_gateway_is_reported(self):
         gateway = self.create_gateway()
-        switch = self.create_switch(gateway, 'FF-AA-BB-CC', '00-00-B1-05')
+        switch = self.create_switch(gateway, '00-01-BB-CC', '00-00-B1-05')
 
         warnings = self.collect_warnings([switch])
         self.assertEqual(len(warnings), 1)
-        self.assertIn('FF-AA-BB-CC', warnings[0])
+        self.assertIn('00-01-BB-CC', warnings[0])
         self.assertIn('00-00-XX-XX', warnings[0])          # names the expected format
         self.assertIn('fgw14usb', warnings[0])             # names the gateway type
 

--- a/tests/test_integration_log.py
+++ b/tests/test_integration_log.py
@@ -64,7 +64,11 @@ class TestTheBuffer(LogTestCase):
         be the serial thread of a gateway. The bug is shown instead of hidden."""
         # noqa: the broken call is the subject of this test - ruff finding it in real code is
         # exactly the point of having the rule switched on
-        self.logger.warning("two placeholders %s %s", "only one argument")  # noqa: PLE1206
+        self.logger.propagate = False
+        try:
+            self.logger.warning("two placeholders %s %s", "only one argument")  # noqa: PLE1206
+        finally:
+            self.logger.propagate = True
 
         entries = integration_log.get_entries(self.hass)['entries']
 

--- a/tests/test_reception.py
+++ b/tests/test_reception.py
@@ -19,7 +19,7 @@ from unittest import TestCase, mock
 from custom_components.eltako.observation import reception
 from custom_components.eltako.observation.reception import quality_of, survey
 
-NOW = datetime(2026, 8, 10, 12, 0, 0, tzinfo=timezone.utc)
+NOW = datetime.now(timezone.utc).replace(microsecond=0)
 
 
 def telegram(seconds_ago: int = 0, **overrides) -> dict:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -66,13 +66,13 @@ class TestSwitch(unittest.TestCase):
         switch.turn_on()
         self.assertEqual(len(self.last_sent_command), 1)
         self.assertEqual(type(self.last_sent_command[0]), Regular4BSMessage)
-        self.assertEqual(self.last_sent_command[0].data[3], 9)
+        self.assertEqual(self.last_sent_command[0].data[3], 13)
         self.last_sent_command = []
 
         switch.turn_off()
         self.assertEqual(len(self.last_sent_command), 1)
         self.assertEqual(type(self.last_sent_command[0]), Regular4BSMessage)
-        self.assertEqual(self.last_sent_command[0].data[3], 8)
+        self.assertEqual(self.last_sent_command[0].data[3], 12)
         self.last_sent_command = []
 
     def test_switch_value_changed_with_sender_epp_F6_02_01_left(self):

--- a/tests/test_switchable_light.py
+++ b/tests/test_switchable_light.py
@@ -181,7 +181,7 @@ class TestSwitchableLight(unittest.TestCase):
         light.turn_on()
         self.assertEqual(
             self.last_sent_command[0].body,
-            b'k\x07\x01\x00\x00\t\x00\x00\xb0\x01\x00')
+            b'k\x07\x01\x00\x00\r\x00\x00\xb0\x01\x00')
 
     def test_switchable_light_trun_off(self):
         light = self.create_switchable_light()
@@ -192,7 +192,7 @@ class TestSwitchableLight(unittest.TestCase):
         light.turn_off()
         self.assertEqual(
             self.last_sent_command[0].body,
-            b'k\x07\x01\x00\x00\x08\x00\x00\xb0\x01\x00')
+            b'k\x07\x01\x00\x00\x0c\x00\x00\xb0\x01\x00')
 
     def test_initial_loading_on(self):
         sl = self.create_switchable_light()


### PR DESCRIPTION
Various little fixes done with Antigravity, tested on my own HomeAssistant:

Climate Controller: Appended thermostat byte address instead of AddressExpression to listen_to_addresses. Added temperature clamping (0.0 to 40.0) and fallback (20.0) in _send_command to prevent crashes. Enabled sending preset commands directly.
Core Entity: Replaced strict type whitelisting with hasattr(msg, 'address') to support arbitrary telegram types, and wrapped value_changed in a try...except block to prevent exceptions from crashing the event dispatcher thread.
Gateway: Bypassed bus gateway validation warnings for wireless actuators.
Switching Command: Set the lock flag in CentralCommandSwitching to 1 (yielding lock=1), ensuring FSR14/FUD14 actuators respond to commands.
Serial Port Delay: Added a default fallback of 0.01 seconds to EnOceanGateway._message_delay to prevent TypeError crashes in the eltakobus serial transceiver thread.
BeautifulSoup Warning: Filtered out XMLParsedAsHTMLWarning log noise caused by the third-party enocean dependency on startup.
Unit Tests: Updated unit tests to assert lock=1 command flags, mocked NOW dynamically to resolve time-dependent failures, and forced C.UTF-8 locale in frontend subprocesses.