### PR TITLE
Serialise outgoing telegrams and honour message_delay on ESP3 gateways

### DIFF
--- a/custom_components/eltako/core/gateway.py
+++ b/custom_components/eltako/core/gateway.py
@@ -116,6 +116,8 @@ class EnOceanGateway:
         self.baud_rate = baud_rate
         self._auto_reconnect = auto_reconnect
         self._message_delay = message_delay
+        self._send_lock = asyncio.Lock()
+        self._last_send_time = 0.0
         self.port = port
         self._attr_dev_type = dev_type
         self._attr_serial_path = serial_path
@@ -819,6 +821,28 @@ class EnOceanGateway:
             self._bus.send_repeater_mode(mode)
         )
 
+    async def _send_message_with_delay(self, msg):
+        """Send one telegram, serialised against the other outgoing telegrams.
+
+        ``hass.create_task`` schedules every outgoing telegram as its own task, so
+        several of them can reach ``self._bus.send`` concurrently. The lock puts them
+        back in order, and ``message_delay`` is honoured between them.
+
+        Until now ``message_delay`` was only passed on to ``RS485SerialInterfaceV2``
+        further down, so it had no effect at all for the ESP3 gateways: neither
+        ``ESP3SerialCommunicator`` nor ``TCP2SerialCommunicator`` takes a delay
+        argument. Those gateways are half duplex - while one telegram is going out
+        the gateway cannot receive, so a burst of commands drowns the status
+        telegrams the actuators send back.
+        """
+        async with self._send_lock:
+            wait = (self._message_delay or 0) - (self._loop.time() - self._last_send_time)
+            if wait > 0:
+                await asyncio.sleep(wait)
+            await self._bus.send(msg)
+            self._last_send_time = self._loop.time()
+
+
     def _callback_send_message_to_serial_bus(self, msg):
         """Send one telegram. Called from the dispatcher and by the deferred queue.
 
@@ -841,7 +865,7 @@ class EnOceanGateway:
                 # put message on serial bus
                 # TODO: maybe it makes sense to filter for matching base id. currently all gateways try to send message but only those where base id matches do actually send. FAM14 and FGW14-USB will receive any message.
                 self.hass.create_task(
-                    self._bus.send(msg)
+                    self._send_message_with_delay(msg)
                 )
                 dispatcher_send(self.hass, ELTAKO_GLOBAL_EVENT_BUS_ID, {'gateway':self, 'esp2_msg': msg})
         else:


### PR DESCRIPTION
## What

Serialise outgoing telegrams with an `asyncio.Lock` and keep a minimum gap taken from `message_delay` between them, for every gateway type. One file, +25/-1.

## Why

Two things combine in `_callback_send_message_to_serial_bus`:

1. `hass.create_task()` schedules every outgoing telegram as its own task, so several of them can reach `self._bus.send()` concurrently and interleave on the same serial port.
2. `message_delay` is only passed on as `delay_message=` to `RS485SerialInterfaceV2`. Neither `ESP3SerialCommunicator` nor `TCP2SerialCommunicator` takes a delay argument, so for the ESP3 gateways the configured value has **no effect at all** — while the gateway's `message_delay` sensor still shows it, which is misleading.

ESP3 radio gateways are half duplex: while a telegram is going out, the gateway cannot receive. A burst of commands therefore drowns the status telegrams the actuators send back.

## Measurement

EnOcean USB300, `message_delay: 1.5`, twelve `light.turn_on`/`turn_off` calls issued through the REST API **within 0.26 s**.

Before the change nothing enforced any spacing at all. Afterwards, the intervals between the gateway's own responses — i.e. the real transmission times, the `Send message` debug line is written before the task is queued and is not a reliable indicator:

```
1.388  1.206  1.507  1.506  1.507  1.506  1.507  1.507  1.449  1.437  1.507   [s]
```

All twelve telegrams were sent, none dropped. Actuator status telegrams coming back rose from 2/12 to 4/12 (a comparable run before the change, with commands roughly 1 s apart, returned 2/12).

Single commands are unaffected: when the previous telegram is longer ago than `message_delay`, nothing is waited for.

## Relation to other issues

- This re-proposes **only** the `gateway.py` part of #207, which was closed because it "also bundles unrelated changes that are not part of this focused fix". Credit for the original idea goes to that pull request.
- Related to #185 (ESP3 gateways). This change does not touch the ESP2/ESP3 conversion itself.

## Test plan

- [ ] Send several commands at once (e.g. a group of covers) — telegrams leave `message_delay` apart instead of simultaneously
- [ ] Send a single command after a pause — no added latency
- [ ] Bus gateways (FAM14 / FGW14-USB) behave as before; `delay_message` is still passed to `RS485SerialInterfaceV2` as well
